### PR TITLE
More fixes for GCC and Clang warnings.

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -505,7 +505,7 @@ void BVH::BuildAVX( const bvhvec4* vertices, const unsigned int primCount )
 	// aligned data
 	ALIGNED( 64 ) __m256 binbox[3 * BVHBINS];				// 768 bytes
 	ALIGNED( 64 ) __m256 binboxOrig[3 * BVHBINS];			// 768 bytes
-	ALIGNED( 64 ) unsigned int count[3][BVHBINS] = { 0 };	// 96 bytes
+	ALIGNED( 64 ) unsigned int count[3][BVHBINS]{};			// 96 bytes
 	ALIGNED( 64 ) __m256 bestLBox, bestRBox;				// 64 bytes
 	// some constants
 	static const __m128 max4 = _mm_set1_ps( -1e30f ), half4 = _mm_set1_ps( 0.5f );

--- a/tiny_bvh_renderer.cpp
+++ b/tiny_bvh_renderer.cpp
@@ -84,7 +84,7 @@ int main()
 			int color = (int)(90.0f / (t + 1));
 			line[x >> 2] = level[90 - tinybvh_clamp( color, 0, 90 )];
 		}
-		line[120] = '\n', line[121] = 0, printf( line );
+		line[120] = '\n', line[121] = 0, printf( "%s", line );
 	}
 	// all done.
 	printf( "\nscene: %i spheres, %i triangles.\n", spheres, verts / 3 );


### PR DESCRIPTION
Fixes the following two warnings from clang, and GCC which also dislikes the bare variable in `printf` (-Wformat-security)

Hopefully it doesn't break MSC.

```console
clang++-18 -O2 -Wall -std=c++20 -ggdb -march=native -mavx tiny_bvh_renderer.cpp -o tiny_bvh_renderer
In file included from tiny_bvh_renderer.cpp:4:
./tiny_bvh.h:508:51: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  508 |         ALIGNED( 64 ) unsigned int count[3][BVHBINS] = { 0 };   // 96 bytes
      |                                                          ^
      |                                                          {}
tiny_bvh_renderer.cpp:87:44: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
   87 |                 line[120] = '\n', line[121] = 0, printf( line );
      |                                                          ^~~~
tiny_bvh_renderer.cpp:87:44: note: treat the string as an argument to avoid this
   87 |                 line[120] = '\n', line[121] = 0, printf( line );
      |                                                          ^
      |                                                          "%s", 
2 warnings generated.
```