### PR TITLE
Use `_mm_extract_epi32` with GNU's intrinsics.

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -479,7 +479,11 @@ void BVH::Build( const bvhvec4* vertices, const unsigned int primCount )
 #define ILANE(a,b) a.m128i_i32[b]
 #else
 #define LANE(a,b) a[b]
+#if defined(__GNUC__)
+#define ILANE(a,b) _mm_extract_epi32((a), (b)) // from smmintrin.h
+#else
 #define ILANE(a,b) a[b]
+#endif
 #endif
 inline float halfArea( const __m128 a /* a contains extent of aabb */ )
 {


### PR DESCRIPTION
This might become a discussion piece I'm guessing.

I'm not convinced the existing code is working correctly when built against GCC's library.

The type `_m128i` is defined as a two-component array (64-bits each), so we can't directly index 32-bit ints, and the compiler warns us as such.

```console
tiny_bvh.h:482:23: warning: array subscript 2 is above array bounds of ‘long long int [2]’ [-Warray-bounds=]
  482 | #define ILANE(a,b) a[b]
```

What I can _not_ explain is why it seems to work anyway. For example, this change does not impact the output of `tiny_bvh_renderer`(!), which at least to me seems surprising, and makes me feel like I'm missing something.