### PR TITLE
Remove explicit casts.

### DIFF
--- a/tiny_bvh_fenster.cpp
+++ b/tiny_bvh_fenster.cpp
@@ -69,11 +69,11 @@ void Tick( uint32_t* buf )
 		for (int s = 0; s < 16; s++, i++) if (rays[i].hit.t < 1000)
 		{
 			int primIdx = rays[i].hit.prim;
-			bvhvec3 v0 = *(bvhvec3*)&triangles[primIdx * 3 + 0];
-			bvhvec3 v1 = *(bvhvec3*)&triangles[primIdx * 3 + 1];
-			bvhvec3 v2 = *(bvhvec3*)&triangles[primIdx * 3 + 2];
-			bvhvec3 N = normalize( cross( v1 - v0, v2 - v0 ) );
-			avg += fabs( dot( N, normalize( bvhvec3( 1, 2, 3 ) ) ) );
+			bvhvec3 v0 = triangles[primIdx * 3 + 0];
+			bvhvec3 v1 = triangles[primIdx * 3 + 1];
+			bvhvec3 v2 = triangles[primIdx * 3 + 2];
+			bvhvec3 UN = normalize( cross( v1 - v0, v2 - v0 ) );
+			avg += fabs( dot( UN, normalize( bvhvec3( 1, 2, 3 ) ) ) );
 		}
 		int c = (int)(15.9f * avg);
 		buf[x + y * SCRWIDTH] = c + (c << 8) + (c << 16);


### PR DESCRIPTION
The code gen isn't _exactly_ the same before-and-after, but it's very minor. Some timings in the post after this.

The GCC diff is less clean and slightly worse-looking, but the clang one looks okay to me.

I understand if you prefer the casting in the end.

(Before this example was updated, I got it bit-exact by using adding a conversion function[^1] to the `TriVertex` type.
I imagine it would be possible to do the same directly on the `bvhvec4`, but that's a more intrusive change.)

[^1]: i.e `operator bvhvec3&() const { return *(bvhvec3*)(this); }`

```diff
$ diff -u asm-orig-clang++-19-tiny_bvh_fenster.s asm-new-clang++-19-tiny_bvh_fenster.s 
--- asm-orig-clang++-19-tiny_bvh_fenster.s	2024-11-02 22:15:59.183094736 +0100
+++ asm-new-clang++-19-tiny_bvh_fenster.s	2024-11-02 22:16:11.761182138 +0100
@@ -735,27 +735,24 @@
 	movslq	%r10d, %r11
 	shlq	$4, %r10
 	shlq	$4, %r11
-	vmovss	4(%r10,%rcx), %xmm7             # xmm7 = mem[0],zero,zero,zero
-	vmovss	8(%r10,%rcx), %xmm8             # xmm8 = mem[0],zero,zero,zero
-	vmovss	(%r10,%rcx), %xmm6              # xmm6 = mem[0],zero,zero,zero
-	vmovss	24(%r11,%rcx), %xmm11           # xmm11 = mem[0],zero,zero,zero
-	vmovss	36(%r11,%rcx), %xmm13           # xmm13 = mem[0],zero,zero,zero
-	vmovss	16(%r11,%rcx), %xmm9            # xmm9 = mem[0],zero,zero,zero
-	vmovss	20(%r11,%rcx), %xmm10           # xmm10 = mem[0],zero,zero,zero
-	vmovss	32(%r11,%rcx), %xmm12           # xmm12 = mem[0],zero,zero,zero
-	vmovss	40(%r11,%rcx), %xmm14           # xmm14 = mem[0],zero,zero,zero
-	vsubss	%xmm8, %xmm11, %xmm11
-	vsubss	%xmm7, %xmm13, %xmm13
-	vsubss	%xmm7, %xmm10, %xmm10
-	vsubss	%xmm6, %xmm9, %xmm9
-	vsubss	%xmm6, %xmm12, %xmm12
-	vsubss	%xmm8, %xmm14, %xmm7
-	vmulss	%xmm11, %xmm13, %xmm6
-	vmulss	%xmm10, %xmm12, %xmm8
+	vmovsd	(%r10,%rcx), %xmm6              # xmm6 = mem[0],zero
+	vmovss	8(%r10,%rcx), %xmm11            # xmm11 = mem[0],zero,zero,zero
+	vmovsd	16(%r11,%rcx), %xmm7            # xmm7 = mem[0],zero
+	vmovsd	32(%r11,%rcx), %xmm8            # xmm8 = mem[0],zero
+	vsubps	%xmm6, %xmm7, %xmm9
+	vmovss	24(%r11,%rcx), %xmm7            # xmm7 = mem[0],zero,zero,zero
+	vsubps	%xmm6, %xmm8, %xmm8
+	vmovss	40(%r11,%rcx), %xmm6            # xmm6 = mem[0],zero,zero,zero
+	vmovshdup	%xmm8, %xmm13           # xmm13 = xmm8[1,1,3,3]
+	vmovshdup	%xmm9, %xmm10           # xmm10 = xmm9[1,1,3,3]
+	vsubss	%xmm11, %xmm7, %xmm12
+	vsubss	%xmm11, %xmm6, %xmm7
+	vmulss	%xmm12, %xmm13, %xmm6
 	vfmsub231ss	%xmm7, %xmm10, %xmm6    # xmm6 = (xmm10 * xmm7) - xmm6
 	vmulss	%xmm7, %xmm9, %xmm7
+	vfmsub231ss	%xmm12, %xmm8, %xmm7    # xmm7 = (xmm8 * xmm12) - xmm7
+	vmulss	%xmm10, %xmm8, %xmm8
 	vfmsub231ss	%xmm13, %xmm9, %xmm8    # xmm8 = (xmm9 * xmm13) - xmm8
-	vfmsub231ss	%xmm11, %xmm12, %xmm7   # xmm7 = (xmm12 * xmm11) - xmm7
 	vmulss	%xmm7, %xmm7, %xmm9
 	vfmadd231ss	%xmm6, %xmm6, %xmm9     # xmm9 = (xmm6 * xmm6) + xmm9
 	vfmadd231ss	%xmm8, %xmm8, %xmm9     # xmm9 = (xmm8 * xmm8) + xmm9
```