### PR TITLE
cmake: build all executables

### DIFF
--- a/.github/workflows/tinybvh_sdk_ci.yml
+++ b/.github/workflows/tinybvh_sdk_ci.yml
@@ -15,7 +15,7 @@ jobs:
         config: [Release, Debug]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Packages
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,50 @@
-
 cmake_minimum_required(VERSION 3.20)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-project(tiny_bvh_test LANGUAGES CXX)
+project(tiny_bvh LANGUAGES CXX)
+
+if (APPLE)
+	find_library(COCOA_LIBRARY Cocoa)
+elseif (UNIX)
+	find_package(X11)
+endif()
 
 enable_testing()
 
-## Build test app ##
+add_executable(tiny_bvh_test tiny_bvh_test.cpp)
+add_executable(tiny_bvh_renderer tiny_bvh_renderer.cpp)
+add_executable(tiny_bvh_speedtest tiny_bvh_speedtest.cpp)
+add_executable(tiny_bvh_fenster tiny_bvh_fenster.cpp)
 
-add_executable(${PROJECT_NAME} tiny_bvh_test.cpp)
 if (NOT MSVC)
-  target_compile_options(${PROJECT_NAME} PRIVATE -march=native)
+	set(common_cxx_flags
+		-g -march=native
+	)
+	target_compile_options(tiny_bvh_test PRIVATE ${common_cxx_flags})
+	target_compile_options(tiny_bvh_renderer PRIVATE ${common_cxx_flags})
+	if (NOT APPLE)
+		target_compile_options(tiny_bvh_speedtest PRIVATE ${common_cxx_flags} -fopenmp)
+		target_link_options(tiny_bvh_speedtest PRIVATE -fopenmp)
+	else()
+		# No openmp support in default compiler
+		target_compile_options(tiny_bvh_speedtest PRIVATE ${common_cxx_flags})
+		target_link_options(tiny_bvh_speedtest PRIVATE)
+	endif()
+	target_compile_options(tiny_bvh_fenster PRIVATE ${common_cxx_flags})
+	if (WIN32)
+		target_link_libraries(tiny_bvh_fenster -mwindows)
+	elseif (APPLE)
+		target_link_libraries(tiny_bvh_fenster ${COCOA_LIBRARY})
+	elseif (X11_FOUND)
+		target_link_libraries(tiny_bvh_fenster ${X11_LIBRARIES})
+	endif()
+else()
+	if (WIN32)
+		set_target_properties(tiny_bvh_fenster PROPERTIES WIN32_EXECUTABLE TRUE)
+	endif()
 endif()
 
-add_test(NAME "${PROJECT_NAME}" COMMAND ${PROJECT_NAME})
+add_test(NAME "tiny_bvh_test" COMMAND tiny_bvh_test)

--- a/tiny_bvh_fenster.cpp
+++ b/tiny_bvh_fenster.cpp
@@ -103,7 +103,11 @@ void Init()
 #else
 
 	// build a BVH over the scene
+#if defined(BVH_USEAVX)
 	bvh.BuildAVX( triangles, verts / 3 );
+#else
+	bvh.Build( triangles, verts / 3 );
+#endif
 	bvh.Convert( BVH::WALD_32BYTE, BVH::ALT_SOA );
 
 #endif


### PR DESCRIPTION
My attempt of enabling CMake to build all executables.

I am far from a CMake expert. I tried to make it as explicit and simple as possible to read/follow.

Only `tiny_bvh_test` is actually run, but this should greatly increase the chance of catching build-breaking changes on CI.