### PR TITLE
Support for WASM with EMSCRIPTEN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ elseif (UNIX AND NOT EMSCRIPTEN)
 elseif (EMSCRIPTEN)
 	# To auto generate test pages
 	set(CMAKE_EXECUTABLE_SUFFIX ".html")
+
+	option(ENABLE_ASAN "Enable ASAN on the build (it'll slow down the app)" OFF)
 endif()
 
 enable_testing()
@@ -31,6 +33,10 @@ if (NOT MSVC)
 		-g
 	)
 
+	set(common_link_flags
+		-g
+	)
+
 	if (NOT EMSCRIPTEN)
 		# EMSCRIPTEN doesn't know about archs
 		set(common_cxx_flags
@@ -38,28 +44,37 @@ if (NOT MSVC)
 		)
 	else()
 		# EMSCRIPTEN flags:
-		#	- -sALLOW_MEMORY_GROWTH (allow runtime allocations) (note linker will warn as CMAKE passes CMAKE_CXX_FLAGS to it as well)
-		set(CMAKE_CXX_FLAGS 
-			${CMAKE_CXX_FLAGS} -sALLOW_MEMORY_GROWTH=1
-		)
+		# -sALLOW_MEMORY_GROWTH (allow runtime allocations) (for some reason cmake passes this as a linker flag when in theory it's a compiler one)
+		set(common_link_flags ${common_link_flags} -sALLOW_MEMORY_GROWTH=1)
+
+		# -fsanitize=address (enable ASAN)
+		# More at https://emscripten.org/docs/debugging/Sanitizers.html#address-sanitizer 
+		if (ENABLE_ASAN) 
+			set(common_cxx_flags ${common_cxx_flags} -fsanitize=address)
+			set(common_link_flags ${common_link_flags} -fsanitize=address)
+		endif()
 	endif()
 
 	target_compile_options(tiny_bvh_test PRIVATE ${common_cxx_flags})
+	target_link_options(tiny_bvh_test PRIVATE ${common_link_flags})
+
 	target_compile_options(tiny_bvh_renderer PRIVATE ${common_cxx_flags})
+	target_link_options(tiny_bvh_renderer PRIVATE ${common_link_flags})
 
 	if (NOT APPLE AND NOT EMSCRIPTEN)
 		target_compile_options(tiny_bvh_speedtest PRIVATE ${common_cxx_flags} -fopenmp)
-		target_link_options(tiny_bvh_speedtest PRIVATE -fopenmp)
+		target_link_options(tiny_bvh_speedtest PRIVATE ${common_link_flags} -fopenmp)
 	else()
 		# No openmp support in default compiler
 		target_compile_options(tiny_bvh_speedtest PRIVATE ${common_cxx_flags})
-		target_link_options(tiny_bvh_speedtest PRIVATE)
+		target_link_options(tiny_bvh_speedtest PRIVATE ${common_link_flags})
 	endif()
 
 	if (TARGET tiny_bvh_fenster)
 		# Not all platforms support all targets. E. g.:
 		#	- EMSCRIPTEN doesn't render anything by default (you would need WebGL/WebGPU)
 		target_compile_options(tiny_bvh_fenster PRIVATE ${common_cxx_flags})
+		target_link_options(tiny_bvh_fenster PRIVATE ${common_link_flags})
 		if (WIN32)
 			target_link_libraries(tiny_bvh_fenster -mwindows)
 		elseif (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ elseif (EMSCRIPTEN)
 	set(CMAKE_EXECUTABLE_SUFFIX ".html")
 
 	option(enable_asan "Enable ASAN on the build (it'll slow down the app)" OFF)
-	set()
+
+	set(emcc_simd "fixed" CACHE STRING "SIMD type to use in the build (none, fixed, relaxed)")
+	set_property(CACHE emcc_simd PROPERTY STRINGS none fixed relaxed)
 endif()
 
 enable_testing()
@@ -54,6 +56,14 @@ if (NOT MSVC)
 			set(common_cxx_flags ${common_cxx_flags} -fsanitize=address)
 			set(common_link_flags ${common_link_flags} -fsanitize=address)
 		endif()
+
+		string(TOLOWER "${emcc_simd}" emcc_simd_lower)
+		if (emcc_simd_lower STREQUAL fixed)
+			set(common_cxx_flags ${common_cxx_flags} -msimd128 -mavx)
+		elseif (emcc_simd_lower STREQUAL relaxed)
+			set(common_cxx_flags ${common_cxx_flags} -mrelaxed-simd -mavx)
+		endif()
+
 	endif()
 
 	target_compile_options(tiny_bvh_test PRIVATE ${common_cxx_flags})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,11 @@ endif()
 if (NOT MSVC)
 	# Produce debug symbols and set optimization level
 	set(common_cxx_flags
-		-g $<$<CONFIG:Release>:-O3>
+		$<$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Debug>>:-g> $<$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Release>>:-O3>
 	)
 
 	set(common_link_flags
-		-g
+		$<$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Debug>>:-g>
 	)
 
 	if (NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ elseif (EMSCRIPTEN)
 	# To auto generate test pages
 	set(CMAKE_EXECUTABLE_SUFFIX ".html")
 
-	option(ENABLE_ASAN "Enable ASAN on the build (it'll slow down the app)" OFF)
+	option(enable_asan "Enable ASAN on the build (it'll slow down the app)" OFF)
+	set()
 endif()
 
 enable_testing()
@@ -49,7 +50,7 @@ if (NOT MSVC)
 
 		# -fsanitize=address (enable ASAN)
 		# More at https://emscripten.org/docs/debugging/Sanitizers.html#address-sanitizer 
-		if (ENABLE_ASAN) 
+		if (enable_asan) 
 			set(common_cxx_flags ${common_cxx_flags} -fsanitize=address)
 			set(common_link_flags ${common_link_flags} -fsanitize=address)
 		endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,13 @@ if (NOT MSVC)
 			set(common_link_flags ${common_link_flags} -fsanitize=address)
 		endif()
 
+		# Enable SIMD instructions and AVX intrinsics
 		string(TOLOWER "${emcc_simd}" emcc_simd_lower)
 		if (emcc_simd_lower STREQUAL fixed)
+			# Supported by all browsers https://webassembly.org/features/
 			set(common_cxx_flags ${common_cxx_flags} -msimd128 -mavx)
 		elseif (emcc_simd_lower STREQUAL relaxed)
+			# Supported some browsers https://webassembly.org/features/
 			set(common_cxx_flags ${common_cxx_flags} -mrelaxed-simd -mavx)
 		endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ elseif (EMSCRIPTEN)
 
 	# Enable thread support for WASM (note that you need special http headers now https://emscripten.org/docs/porting/pthreads.html )
 	option(emcc_threads "Enable Threads in WASM (note that means you need to change your http headers)" OFF)
+
+	# Enable C/C++ main thread as a proxy thread to avoid blocking DOM/UI thread https://emscripten.org/docs/porting/pthreads.html
+	option(emcc_proxy_main "Enable C/C++ main thread as a proxy thread to avoid blocking DOM/UI thread" ${emcc_threads})
 endif()
 
 enable_testing()
@@ -90,7 +93,7 @@ if (NOT MSVC)
 	elseif (EMSCRIPTEN)
 		if (emcc_threads)
 			set(tiny_bvh_speedtest_cxx_flags ${tiny_bvh_speedtest_cxx_flags} -pthread)
-			set(tiny_bvh_speedtest_link_flags ${tiny_bvh_speedtest_link_flags} -pthread)
+			set(tiny_bvh_speedtest_link_flags ${tiny_bvh_speedtest_link_flags} -pthread -sUSE_PTHREADS=1 -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency)
 
 			if (FALSE)
 				# From:
@@ -103,6 +106,10 @@ if (NOT MSVC)
 				# Then link it here
 				set(tiny_bvh_speedtest_cxx_flags ${tiny_bvh_speedtest_cxx_flags} -fopenmp)
 				set(tiny_bvh_speedtest_link_flags ${tiny_bvh_speedtest_link_flags} -fopenmp)
+			endif()
+
+			if (emcc_proxy_main)
+				set(tiny_bvh_speedtest_link_flags ${tiny_bvh_speedtest_link_flags} -sPROXY_TO_PTHREAD=1)
 			endif()
 		endif()
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,11 @@ project(tiny_bvh LANGUAGES CXX)
 
 if (APPLE)
 	find_library(COCOA_LIBRARY Cocoa)
-elseif (UNIX)
+elseif (UNIX AND NOT EMSCRIPTEN)
 	find_package(X11)
+elseif (EMSCRIPTEN)
+	# To auto generate test pages
+	set(CMAKE_EXECUTABLE_SUFFIX ".html")
 endif()
 
 enable_testing()
@@ -17,15 +20,34 @@ enable_testing()
 add_executable(tiny_bvh_test tiny_bvh_test.cpp)
 add_executable(tiny_bvh_renderer tiny_bvh_renderer.cpp)
 add_executable(tiny_bvh_speedtest tiny_bvh_speedtest.cpp)
-add_executable(tiny_bvh_fenster tiny_bvh_fenster.cpp)
+if (NOT EMSCRIPTEN)
+	# EMSCRIPTEN doesn't render anything by default (you would need WebGL/WebGPU)
+	add_executable(tiny_bvh_fenster tiny_bvh_fenster.cpp)
+endif()
 
 if (NOT MSVC)
+	# Produce debug symbols
 	set(common_cxx_flags
-		-g -march=native
+		-g
 	)
+
+	if (NOT EMSCRIPTEN)
+		# EMSCRIPTEN doesn't know about archs
+		set(common_cxx_flags
+			${common_cxx_flags} -march=native
+		)
+	else()
+		# EMSCRIPTEN flags:
+		#	- -sALLOW_MEMORY_GROWTH (allow runtime allocations) (note linker will warn as CMAKE passes CMAKE_CXX_FLAGS to it as well)
+		set(CMAKE_CXX_FLAGS 
+			${CMAKE_CXX_FLAGS} -sALLOW_MEMORY_GROWTH=1
+		)
+	endif()
+
 	target_compile_options(tiny_bvh_test PRIVATE ${common_cxx_flags})
 	target_compile_options(tiny_bvh_renderer PRIVATE ${common_cxx_flags})
-	if (NOT APPLE)
+
+	if (NOT APPLE AND NOT EMSCRIPTEN)
 		target_compile_options(tiny_bvh_speedtest PRIVATE ${common_cxx_flags} -fopenmp)
 		target_link_options(tiny_bvh_speedtest PRIVATE -fopenmp)
 	else()
@@ -33,13 +55,18 @@ if (NOT MSVC)
 		target_compile_options(tiny_bvh_speedtest PRIVATE ${common_cxx_flags})
 		target_link_options(tiny_bvh_speedtest PRIVATE)
 	endif()
-	target_compile_options(tiny_bvh_fenster PRIVATE ${common_cxx_flags})
-	if (WIN32)
-		target_link_libraries(tiny_bvh_fenster -mwindows)
-	elseif (APPLE)
-		target_link_libraries(tiny_bvh_fenster ${COCOA_LIBRARY})
-	elseif (X11_FOUND)
-		target_link_libraries(tiny_bvh_fenster ${X11_LIBRARIES})
+
+	if (TARGET tiny_bvh_fenster)
+		# Not all platforms support all targets. E. g.:
+		#	- EMSCRIPTEN doesn't render anything by default (you would need WebGL/WebGPU)
+		target_compile_options(tiny_bvh_fenster PRIVATE ${common_cxx_flags})
+		if (WIN32)
+			target_link_libraries(tiny_bvh_fenster -mwindows)
+		elseif (APPLE)
+			target_link_libraries(tiny_bvh_fenster ${COCOA_LIBRARY})
+		elseif (X11_FOUND)
+			target_link_libraries(tiny_bvh_fenster ${X11_LIBRARIES})
+		endif()
 	endif()
 else()
 	if (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,15 @@ elseif (EMSCRIPTEN)
 	# To auto generate test pages
 	set(CMAKE_EXECUTABLE_SUFFIX ".html")
 
+	# Enable clang's Address Sanitizer for WASM
 	option(enable_asan "Enable ASAN on the build (it'll slow down the app)" OFF)
 
+	# Enable wasm SIMD instructions
 	set(emcc_simd "fixed" CACHE STRING "SIMD type to use in the build (none, fixed, relaxed)")
 	set_property(CACHE emcc_simd PROPERTY STRINGS none fixed relaxed)
+
+	# Enable thread support for WASM (note that you need special http headers now https://emscripten.org/docs/porting/pthreads.html )
+	option(emcc_threads "Enable Threads in WASM (note that means you need to change your http headers)" OFF)
 endif()
 
 enable_testing()
@@ -75,14 +80,34 @@ if (NOT MSVC)
 	target_compile_options(tiny_bvh_renderer PRIVATE ${common_cxx_flags})
 	target_link_options(tiny_bvh_renderer PRIVATE ${common_link_flags})
 
+	# No openmp support in default compiler
+	set(tiny_bvh_speedtest_cxx_flags ${common_cxx_flags})
+	set(tiny_bvh_speedtest_link_flags ${common_link_flags})
+
 	if (NOT APPLE AND NOT EMSCRIPTEN)
-		target_compile_options(tiny_bvh_speedtest PRIVATE ${common_cxx_flags} -fopenmp)
-		target_link_options(tiny_bvh_speedtest PRIVATE ${common_link_flags} -fopenmp)
-	else()
-		# No openmp support in default compiler
-		target_compile_options(tiny_bvh_speedtest PRIVATE ${common_cxx_flags})
-		target_link_options(tiny_bvh_speedtest PRIVATE ${common_link_flags})
+		set(tiny_bvh_speedtest_cxx_flags ${tiny_bvh_speedtest_cxx_flags} -fopenmp)
+		set(tiny_bvh_speedtest_link_flags ${tiny_bvh_speedtest_link_flags} -fopenmp)
+	elseif (EMSCRIPTEN)
+		if (emcc_threads)
+			set(tiny_bvh_speedtest_cxx_flags ${tiny_bvh_speedtest_cxx_flags} -pthread)
+			set(tiny_bvh_speedtest_link_flags ${tiny_bvh_speedtest_link_flags} -pthread)
+
+			if (FALSE)
+				# From:
+				#	- https://github.com/llvm/llvm-project/pull/95169 
+				#	- https://github.com/llvm/llvm-project/pull/71297 
+				#	- https://reviews.llvm.org/D142593?id=492403
+				# llvm's and clang's OpenMP has been ported to WASM around August 2024
+				# Sadly emcc's clang doesn't include a copy of the lib
+				# So you would need to do compile it yourself https://github.com/abrown/wasm-openmp-examples/blob/main/emscripten.sh
+				# Then link it here
+				set(tiny_bvh_speedtest_cxx_flags ${tiny_bvh_speedtest_cxx_flags} -fopenmp)
+				set(tiny_bvh_speedtest_link_flags ${tiny_bvh_speedtest_link_flags} -fopenmp)
+			endif()
+		endif()
 	endif()
+	target_compile_options(tiny_bvh_speedtest PRIVATE ${tiny_bvh_speedtest_cxx_flags})
+	target_link_options(tiny_bvh_speedtest PRIVATE ${tiny_bvh_speedtest_link_flags})
 
 	if (TARGET tiny_bvh_fenster)
 		# Not all platforms support all targets. E. g.:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,9 @@ if (NOT EMSCRIPTEN)
 endif()
 
 if (NOT MSVC)
-	# Produce debug symbols
+	# Produce debug symbols and set optimization level
 	set(common_cxx_flags
-		-g
+		-g $<$<CONFIG:Release>:-O3>
 	)
 
 	set(common_link_flags

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -69,7 +69,7 @@ THE SOFTWARE.
 #define BVHBINS 8
 
 // include fast AVX BVH builder
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__x86_64__) || defined(_M_X64) || defined(__wasm_simd128__) || defined(__wasm_relaxed_simd__)
 #define BVH_USEAVX
 #endif
 
@@ -99,8 +99,8 @@ THE SOFTWARE.
 #include <cmath>
 #include <cstring>
 #define ALIGNED( x ) __attribute__( ( aligned( x ) ) )
-#if defined(__x86_64__) || defined(_M_X64)
-// https://stackoverflow.com/questions/32612881/why-use-mm-malloc-as-opposed-to-aligned-malloc-alligned-alloc-or-posix-mem
+#if defined(__wasm_simd128__) || defined(__wasm_relaxed_simd__)
+// https://emscripten.org/docs/porting/simd.html
 #include <xmmintrin.h>
 #define ALIGNED_MALLOC( x ) ( ( x ) == 0 ? 0 : _mm_malloc( ( x ), 64 ) )
 #define ALIGNED_FREE( x ) _mm_free( x )

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -2596,6 +2596,8 @@ static unsigned __bfind( unsigned x ) // https://github.com/mackron/refcode/blob
 {
 #if defined(_MSC_VER) && !defined(__clang__)
 	return 31 - __lzcnt( x );
+#elif defined(__EMSCRIPTEN__)
+	return 31 - __builtin_clz(x);
 #elif defined(__GNUC__) || defined(__clang__)
 	unsigned r;
 	__asm__ __volatile__( "lzcnt{l %1, %0| %0, %1}" : "=r"(r) : "r"(x) : "cc" );

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -109,7 +109,7 @@ THE SOFTWARE.
 #else
 // Size needs to be a multiple of Alignment in the standard (in EMSCRIPTEN this is enforced)
 // See https://en.cppreference.com/w/c/memory/aligned_alloc
-#define MAKE_MULIPLE_64( x ) ( ( x + 63 ) & ( ~0x3f ) )
+#define MAKE_MULIPLE_64( x ) ( ( ( x ) + 63 ) & ( ~0x3f ) )
 #define ALIGNED_MALLOC( x ) ( ( x ) == 0 ? 0 : aligned_alloc( 64, MAKE_MULIPLE_64( x ) ) )
 #define ALIGNED_FREE( x ) free( x )
 #endif

--- a/tiny_bvh_speedtest.cpp
+++ b/tiny_bvh_speedtest.cpp
@@ -411,6 +411,6 @@ int main()
 
 #endif
 
-	// all done.
+	printf( "all done." );
 	return 0;
 }

--- a/tiny_bvh_speedtest.cpp
+++ b/tiny_bvh_speedtest.cpp
@@ -9,6 +9,9 @@
 #ifdef _WIN32
 #include <intrin.h>		// for __cpuidex
 #endif
+#ifdef __EMSCRIPTEN__ 
+#include <emscripten/version.h> // for __EMSCRIPTEN_major__, __EMSCRIPTEN_minor__
+#endif
 
 // 'screen resolution': see tiny_bvh_fenster.cpp; this program traces the
 // same rays, but without visualization - just performance statistics.
@@ -122,6 +125,9 @@ int main()
 	// determine compiler
 #ifdef _MSC_VER
 	printf( "(MSVC %i build)\n", _MSC_VER );
+#elif defined __EMSCRIPTEN__
+	// EMSCRIPTEN needs to be before clang or gcc
+	printf("(emcc %i.%i build)\n", __EMSCRIPTEN_major__, __EMSCRIPTEN_minor__);
 #elif defined __clang__
 	printf( "(clang %i.%i build)\n", __clang_major__ , __clang_minor__ );
 #elif defined __GNUC__


### PR DESCRIPTION
Hello! I'm playing with WASM through EMSCRIPTEN and decided to test the library to it 😄

Most of the changes are to the CMake file to get the right flags to the compiler.  

## Limitations

There are two big limitations though:

- Fenster is not supported as that would require a WebGL/WebGPU context to render
- OpenMP is not working. More info in the CMake file, but the short story is that the OpenMP library was recently ported and the lib is not included by default with the compiler (I might try later to compile it and link it, but probably won't commit it as that'll be a big change)

## Results

From running in my Chrome browser, I get the next numbers (MT numbers are wrong as OpenMP is not enabled):

```
tiny_bvh version 0.7.2 performance statistics (emcc 3.1 build)
----------------------------------------------------------------
BVH construction speed
warming caches...
- reference builder:  405.86ms for  152292 triangles - 249218 nodes, SAH=96.91
- fast AVX builder:   131.31ms for  152292 triangles - 248966 nodes, SAH=96.87
- HQ (SBVH) builder: 2948.63ms for  152292 triangles - 272018 nodes, SAH=94.88
BVH traversal speed
- CPU, coherent,   basic 2-way layout, ST:   5774.2ms for   7.68M rays =>   1.33MRay/s
- CPU, coherent,   alt 2-way layout,   ST:   5687.8ms for   7.68M rays =>   1.35MRay/s
- CPU, coherent,   soa 2-way layout,   ST:   6355.1ms for   7.68M rays =>   1.21MRay/s
- CPU, coherent,   basic 2-way layout, MT:   5564.1ms for   7.68M rays =>   1.38MRay/s
- CPU, coherent,   2-way, packets,     MT:   1318.4ms for   7.68M rays =>   5.83MRay/s
- CPU, coherent,   2-way, packets/SSE, MT:   1082.2ms for   7.68M rays =>   7.10MRay/s
Optimizing BVH... done (9.10s). New SAH=87.76
- CPU, coherent,   2-way optimized,    ST:   6000.2ms for   7.68M rays =>   1.28MRay/s
- CPU, incoherent, basic 2-way layout, MT:  11005.1ms for   7.68M rays =>   0.70MRay/s
```

![image](https://github.com/user-attachments/assets/ecb30a16-412b-42fa-9ec9-8b0e5b3a12c0)

## How to compile and run

0. Download the EMSCRIPTEN compiler [here](https://emscripten.org/docs/getting_started/downloads.html)
1. Start a terminal with the emsdk environment (For Windows ```emsdk\emsdk.bat activate latest```)
2. Configure CMake, e. g.: ```emcmake cmake -S . -B ./build/web -G "Ninja Multi-Config" -Demcc_threads=ON -Demcc_proxy_main=ON```
3. Build with: ``` cmake --build .\build\web\ --config Release```
4. Use a HTTP server for testing. E. g. with [this](https://github.com/maniatic0/emcc-test-server): ```python custom-http.py -d .\build\web\Release\```
5. Go to ```localhost:8000``` and click a HTML page to test 😄
