### PR TITLE
ISNVIDIA preprocessor fix

### DIFF
--- a/traverse.cl
+++ b/traverse.cl
@@ -252,12 +252,14 @@ void kernel traverse_gpu4way( global float4* alt4Node, global struct Ray* rayDat
 #ifdef ISINTEL // Iris Xe, Arc, ..
 // #define USE_VLOAD_VSTORE
 #define SIMD_AABBTEST
-#elif define ISNVIDIA // 2080, 3080, 4080, ..
+#elif defined ISNVIDIA // 2080, 3080, 4080, ..
 #define USE_VLOAD_VSTORE
 // #define SIMD_AABBTEST
-#else // AMD, .. : untested
+#elif defined ISAMD
 #define USE_VLOAD_VSTORE
 #define SIMD_AABBTEST
+#else  // ARM, .. : untested
+
 #endif
 
 #ifdef USE_VLOAD_VSTORE


### PR DESCRIPTION
I was reciving this error on AMD RX 570 GPU
error: token is not a valid binary operator in a preprocessor subexpression
#elif define ISNVIDIA // 2080, 3080, 4080,