### PR TITLE
add a new AMD gpu name to tiny_ocl.h

### DIFF
--- a/tiny_ocl.h
+++ b/tiny_ocl.h
@@ -1007,7 +1007,7 @@ bool Kernel::InitCL()
 			if (strstr( d, "titan x" )) isPascal = true;
 		}
 	}
-	else if (strstr( d, "amd" ) || strstr( d, "ellesmere" ) || strstr( d, "gfx1100" ) || strstr( d, "AMD" )) // JdW
+	else if (strstr( d, "amd" ) || strstr( d, "ellesmere" ) || strstr( d, "gfx1100" ) || strstr( d, "gfx1031" ) || strstr( d, "AMD" )) // JdW
 	{
 		isAMD = true;
 	}


### PR DESCRIPTION
AMD Radeon 6700 XT returns "gfx1031" for CL_DEVICE_NAME.

I also tried CL_DEVICE_VENDOR and it returned "Advanced Micro Devices, Inc.", maybe this could be easier to check.