### PR TITLE
Add bvhvec4slice to Build()/BuildHQ()

### DIFF
--- a/tiny_bvh_speedtest.cpp
+++ b/tiny_bvh_speedtest.cpp
@@ -643,7 +643,7 @@ int main()
 	// create OpenCL buffers for the BVH data calculated by tiny_bvh.h
 	tinyocl::Buffer gpuNodes( bvh.usedAltNodes * sizeof( BVH::BVHNodeAlt ), bvh.altNode );
 	tinyocl::Buffer idxData( bvh.idxCount * sizeof( unsigned ), bvh.triIdx );
-	tinyocl::Buffer triData( bvh.triCount * 3 * sizeof( tinybvh::bvhvec4 ), bvh.verts );
+	tinyocl::Buffer triData( bvh.triCount * 3 * sizeof( tinybvh::bvhvec4 ), triangles );
 	// synchronize the host-side data to the gpu side
 	gpuNodes.CopyToDevice();
 	idxData.CopyToDevice();


### PR DESCRIPTION
Sorry for the drive by cleanup, I have a plugin to remove trailing whitespaces, didn't realize since it autoruns on save :) If you want I can eventually revert those changes.

Would be great to add bound checks to the slice in debug mode. Haven't done that yet. Should we add a `DEBUG` define?

