### PR TITLE
API overhaul.

### DIFF
--- a/tiny_bvh_fenster.cpp
+++ b/tiny_bvh_fenster.cpp
@@ -12,6 +12,7 @@
 using namespace tinybvh;
 
 BVH bvh;
+BVH_SoA bvh2;
 
 #ifdef LOADSCENE
 bvhvec4* triangles = 0;
@@ -79,6 +80,7 @@ void Init()
 #else
 	bvh.Build( triangles, verts / 3 );
 #endif
+	bvh2.ConvertFrom( bvh );
 
 	// load camera position / direction from file
 	std::fstream t = std::fstream{ "camera.bin", t.binary | t.in };
@@ -133,7 +135,7 @@ void Tick(float delta_time_s, fenster & f, uint32_t* buf)
 	}
 
 	// trace primary rays
-	for (int i = 0; i < N; i++) depths[i] = bvh.Intersect( rays[i] );
+	for (int i = 0; i < N; i++) depths[i] = bvh2.Intersect( rays[i] );
 
 	// visualize result
 	const bvhvec3 L = normalize( bvhvec3( 1, 2, 3 ) );

--- a/tiny_bvh_minimal.cpp
+++ b/tiny_bvh_minimal.cpp
@@ -51,8 +51,8 @@ int main()
 	{
 		tinybvh::BVH bvh;
 		bvh.Build( triangles, TRIANGLE_COUNT );
-		bvh.Convert( tinybvh::BVH::WALD_32BYTE, tinybvh::BVH::VERBOSE );
-		bvh.Refit( tinybvh::BVH::VERBOSE );
+		// bvh.Convert( tinybvh::BVH::WALD_32BYTE, tinybvh::BVH::VERBOSE );
+		// bvh.Refit( tinybvh::BVH::VERBOSE );
 
 		// from here: play with the BVH!
 		int steps = bvh.Intersect( ray );


### PR DESCRIPTION
Major API overhaul based on discussion with David Peicho:
Instead of having one big BVH class, there is now multiple classes, one for each layout. Only the 'BVH' layout (formerly: WALD_32BYTE) and 'BVH_Double' can be built; all others are constructed from other types. In most cases from BVH itself, e.g.: BVH_GPU (formerly known as Aila_Laine) now takes a const BVH reference in it's constructor.
Repeated updates can be done with calls to ConvertFrom; buffers will only be re-allocated in that case if capacity is exceeded. This is the same behavior we had before.

This breaks existing applications. One exception: the 'minimal' example works without changes. :)
See the Fenster app for a good example of building one type and converting to a second layout.
See Speedtest for extensive use of all layouts.

The changes have no impact on performance. Changes will reside in the dev branch for a while - until we are sure nothing is broken. Feedback welcome!