### PR TITLE
Replace OpenMP with cpp11 threads

### DIFF
--- a/tiny_bvh_speedtest.cpp
+++ b/tiny_bvh_speedtest.cpp
@@ -266,7 +266,6 @@ static std::atomic<int> batchIdx(0);
 void IntersectBvhWorkerThread(int batchCount, Ray* fullBatch, int threadIdx)
 {
 	int batch = threadIdx;
-
 	while (batch < batchCount)
 	{
 		const int batchStart = batch * 10000;
@@ -283,7 +282,6 @@ void IntersectBvhWorkerThread(int batchCount, Ray* fullBatch, int threadIdx)
 void IntersectBvh256WorkerThread(int batchCount, Ray* fullBatch, int threadIdx)
 {
 	int batch = threadIdx;
-
 	while (batch < batchCount)
 	{
 		const int batchStart = batch * 30 * 256;
@@ -300,7 +298,6 @@ void IntersectBvh256WorkerThread(int batchCount, Ray* fullBatch, int threadIdx)
 void IntersectBvh256SSEWorkerThread(int batchCount, Ray* fullBatch, int threadIdx)
 {
 	int batch = threadIdx;
-
 	while (batch < batchCount)
 	{
 		const int batchStart = batch * 30 * 256;


### PR DESCRIPTION
This removes the OpenMP parallelism directives and introduces parallelism based on C++11 threads. I have checked the benchmark results, and the timings for the parallel runs were more or less the same.