### PR TITLE
Fixed memory leak in tiny_bvh_fenster

### DIFF
--- a/tiny_bvh_fenster.cpp
+++ b/tiny_bvh_fenster.cpp
@@ -153,6 +153,7 @@ void Tick(float delta_time_s, fenster & f, uint32_t* buf)
 		}
 	}
 	tinybvh::free64( rays );
+	tinybvh::free64(depths);
 }
 
 void Shutdown()


### PR DESCRIPTION
Depth buffer never got released in ``Tick()``