### PR TITLE
Install libx11-dev on Ubuntu

### DIFF
--- a/.github/workflows/tinybvh_sdk_ci.yml
+++ b/.github/workflows/tinybvh_sdk_ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Install Packages
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: sudo apt install -y libboost-system-dev
+      run: sudo apt install -y libboost-system-dev libx11-dev
 
     - name: Configure CMake
       run: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,7 @@ add_executable(tiny_bvh_minimal tiny_bvh_minimal.cpp)
 add_executable(tiny_bvh_renderer tiny_bvh_renderer.cpp)
 add_executable(tiny_bvh_speedtest tiny_bvh_speedtest.cpp)
 if (NOT EMSCRIPTEN) # EMSCRIPTEN doesn't render anything by default (you would need WebGL/WebGPU)
-if (NOT UNIX) # For some reason, X11 suddenly broke on Github.	
 	add_executable(tiny_bvh_fenster tiny_bvh_fenster.cpp)
-endif()
 endif()
 
 target_include_directories(tiny_bvh_speedtest PRIVATE ${CMAKE_CURRENT_LIST_DIR}/external/OpenCL/inc)


### PR DESCRIPTION
Presumably the change of github's 'ubuntu-latest' image to 24.04 meant that the X11 dev libraries were no longer available by default. No doubt more will break as the Wayland future creeps up on us, but that's for another day.

I guess I should have targetted the 'dev' branch...

Fixes #79 