### PR TITLE
fix including of wasm simd header with tinybvh_no_simd

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -177,7 +177,7 @@ inline void free64( void* ptr, void* = nullptr ) { _aligned_free( ptr ); }
 }
 #else // EMSCRIPTEN / gcc / clang
 #define ALIGNED( x ) __attribute__( ( aligned( x ) ) )
-#if defined(__x86_64__) || defined(_M_X64) || defined(__wasm_simd128__) || defined(__wasm_relaxed_simd__)
+#if !defined(TINYBVH_NO_SIMD) && (defined(__x86_64__) || defined(_M_X64) || defined(__wasm_simd128__) || defined(__wasm_relaxed_simd__))
 #include <xmmintrin.h>
 namespace tinybvh {
 inline void* malloc64( size_t size, void* = nullptr )


### PR DESCRIPTION
There's one more wasm simd header being pulled in when TINYBVH_NO_SIMD is defined. Added a ifndef guard around that so it will fall back to the non-simd case.