### PR TITLE
Memory leak and start-up project

### DIFF
--- a/tiny_bvh_fenster.cpp
+++ b/tiny_bvh_fenster.cpp
@@ -159,8 +159,6 @@ void Tick( float delta_time_s, fenster& f, uint32_t* buf )
 	// generate primary rays in a cacheline-aligned buffer - and, for data locality:
 	// organized in 4x4 pixel tiles, 16 samples per pixel, so 256 rays per tile.
 	int N = 0;
-	Ray* rays = (Ray*)tinybvh::malloc64( SCRWIDTH * SCRHEIGHT * 16 * sizeof( Ray ) );
-	int* depths = (int*)tinybvh::malloc64( SCRWIDTH * SCRHEIGHT * sizeof( int ) );
 	for (int ty = 0; ty < SCRHEIGHT; ty += 4) for (int tx = 0; tx < SCRWIDTH; tx += 4)
 	{
 		for (int y = 0; y < 4; y++) for (int x = 0; x < 4; x++)

--- a/tiny_bvh_test.sln
+++ b/tiny_bvh_test.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tiny_bvh_gpu", "vcproj\tiny_bvh_gpu.vcxproj", "{4B0A219D-68D0-41EA-A0C4-8EB9E6171218}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tiny_bvh_fenster", "vcproj\tiny_bvh_fenster.vcxproj", "{C668A5EF-8E6A-4060-89C2-ED0AFFF0EE90}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tiny_bvh_renderer", "vcproj\tiny_bvh_renderer.vcxproj", "{103715F7-8E20-4058-B18C-CAF6E36F23B2}"
@@ -12,8 +14,6 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tiny_bvh_minimal", "vcproj\tiny_bvh_minimal.vcxproj", "{0B5C86B2-9438-49E3-BF1A-4E1593BB436D}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tiny_bvh_pt", "vcproj\tiny_bvh_pt.vcxproj", "{430FCECF-7685-40A7-A415-4A0DE487158F}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tiny_bvh_gpu", "vcproj\tiny_bvh_gpu.vcxproj", "{4B0A219D-68D0-41EA-A0C4-8EB9E6171218}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tiny_bvh_custom", "vcproj\tiny_bvh_custom.vcxproj", "{05E87951-A43C-49D9-BC3B-5F6387285D2E}"
 EndProject


### PR DESCRIPTION
This issue was already fixed in Dec. But looks like it's still an issue.

Looking at the [history](https://github.com/jbikker/tinybvh/commits/main/tiny_bvh_fenster.cpp) of ``tiny_bvh_fenster.cpp``, after my old pr #58  got merged. Commit 05e07c2ceea2166f0dac0e7d868b65c074acffbf seemed to revert the change unknowingly.

Then on Dec 16 @TheSFReader fixed it again with commit 57eb3bc512bad52faa2c80c9b7733abf8c264cf5. But then the fix got moved to ``Shutdown()`` by @jbikker in commit a2b4fe07ae4e93cc4377877fefd7f935ce4fecf7 even though the buffers get allocated every frame. Not sure why this allocation is here in the first place? There is already a ``rays`` and ``depts`` buffer in global space that gets allocated in ``Init()``.

tiny_bvh_fenster is the default start-up project so anyone who downloads it, the first thing they see is this project.

The changes I made with this new pr:
1. Removed the allocation every frame.
2. Made tiny_bvh_gpu the default start-up project. This is, in my opinion, a better first impression compared to fenster.