### PR TITLE
Fix issue #95.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# dev
-This is the **development branch** for tinybvh.
-
 # tinybvh
 Single-header BVH construction and traversal library written as "Sane C++" (or "C with classes"). Some C++11 is used, e.g. for threading. The library has no dependencies. 
 
@@ -72,7 +69,7 @@ The **performance measurement tool** can be compiled with:
 
 ````g++ -std=c++20 -mavx -Ofast tiny_bvh_speedtest.cpp -o tiny_bvh_speedtest````
 
-# Version 1.3.2
+# Version 1.3.3
 
 Version 1.3.0 changed the names of vector math functions, which are now prepended with ````tinybvh_````, e.g. ````tinybvh_cross````, ````tinybvh_normalize````. This avoids name clashes in applications that override the vector types with their own. Basically tinybvh evades these so you don't have to. 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# dev
+This is the **development branch** for tinybvh.
+
 # tinybvh
 Single-header BVH construction and traversal library written as "Sane C++" (or "C with classes"). Some C++11 is used, e.g. for threading. The library has no dependencies. 
 

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -159,7 +159,7 @@ THE SOFTWARE.
 // library version
 #define TINY_BVH_VERSION_MAJOR	1
 #define TINY_BVH_VERSION_MINOR	3
-#define TINY_BVH_VERSION_SUB	2
+#define TINY_BVH_VERSION_SUB	3
 
 // ============================================================================
 //
@@ -440,8 +440,8 @@ inline bvhdbl3 operator*( double b, const bvhdbl3& a ) { return bvhdbl3( b * a.x
 inline bvhdbl3 operator/( double b, const bvhdbl3& a ) { return bvhdbl3( b / a.x, b / a.y, b / a.z ); }
 inline bvhdbl3 operator*=( bvhdbl3& a, const double b ) { return bvhdbl3( a.x * b, a.y * b, a.z * b ); }
 
-static double tinybvh_length( const bvhdbl3& a ) { return sqrt( a.x * a.x + a.y * a.y + a.z * a.z ); }
-static bvhdbl3 tinybvh_normalize( const bvhdbl3& a )
+double tinybvh_length( const bvhdbl3& a ) { return sqrt( a.x * a.x + a.y * a.y + a.z * a.z ); }
+bvhdbl3 tinybvh_normalize( const bvhdbl3& a )
 {
 	double l = tinybvh_length( a ), rl = l == 0 ? 0 : (1.0 / l);
 	return a * rl;
@@ -502,6 +502,7 @@ typedef bvhvec4 SIMDVEC4;
 #endif
 
 // error handling
+#define FATAL_ERROR(s) FATAL_ERROR_IF(1,s)
 #define FATAL_ERROR_IF(c,s) if (c) { fprintf( stderr, \
 	"Fatal error in tiny_bvh.h, line %i:\n%s\n", __LINE__, s ); exit( 1 ); }
 
@@ -5559,6 +5560,30 @@ bool BVH4_CPU::IsOccluded( const Ray& ray ) const
 }
 
 #endif // BVH_USENEON
+
+#if !defined( BVH_USEAVX ) && !defined( BVH_USENEON )
+
+int32_t BVH_SoA::Intersect( Ray& ray ) const
+{
+	FATAL_ERROR( "BVH_SoA::Intersect: Requires AVX or NEON." );
+}
+
+bool BVH_SoA::IsOccluded( const Ray& ray ) const
+{
+	FATAL_ERROR( "BVH_SoA::IsOccluded: Requires AVX or NEON." );
+}
+
+int32_t BVH4_CPU::Intersect( Ray& ray ) const
+{
+	FATAL_ERROR( "BVH4_CPU::Intersect: Requires AVX or NEON." );
+}
+
+bool BVH4_CPU::IsOccluded( const Ray& ray ) const
+{
+	FATAL_ERROR( "BVH4_CPU::IsOccluded: Requires AVX or NEON." );
+}
+
+#endif
 
 // ============================================================================
 //

--- a/tiny_bvh_anim.cpp
+++ b/tiny_bvh_anim.cpp
@@ -8,6 +8,7 @@
 #define INSTCOUNT (GRIDSIZE * GRIDSIZE * GRIDSIZE)
 
 #define TINYBVH_IMPLEMENTATION
+#define TINYBVH_NO_SIMD
 #define INST_IDX_BITS 8 // override default; space for 256 instances.
 #include "tiny_bvh.h"
 #include <fstream>
@@ -17,7 +18,7 @@ using namespace tinybvh;
 
 struct Sphere { bvhvec3 pos; float r; };
 
-BVH4_CPU sponza;
+BVH sponza;
 BVH obj; // custom geometry BVH must be regular BVH layout.
 BVH tlas; // TLAS must for now be in regular BVH layout.
 BVHBase* bvhList[] = { &sponza, &obj };
@@ -148,7 +149,7 @@ void TraceWorkerThread( uint32_t* buf, int threadIdx )
 			// setup primary ray
 			const float u = (float)pixel_x / SCRWIDTH, v = (float)pixel_y / SCRHEIGHT;
 			const bvhvec3 D = tinybvh_normalize( p1 + u * (p2 - p1) + v * (p3 - p1) - eye );
-			Ray ray( eye, D, 1e30f );
+			Ray ray( eye, D );
 			tlas.Intersect( ray );
 			if (ray.hit.t < 10000)
 			{

--- a/tiny_bvh_collide.cpp
+++ b/tiny_bvh_collide.cpp
@@ -104,7 +104,6 @@ void TraceWorkerThread( uint32_t* buf, int threadIdx )
 	while (tile < tiles)
 	{
 		const int tx = tile % xtiles, ty = tile / xtiles;
-		unsigned seed = (tile + 17) * 171717 + frameIdx * 1023;
 		const bvhvec3 L = tinybvh_normalize( bvhvec3( 1, 2, 3 ) );
 		for (int y = 0; y < TILESIZE; y++) for (int x = 0; x < TILESIZE; x++)
 		{
@@ -117,7 +116,6 @@ void TraceWorkerThread( uint32_t* buf, int threadIdx )
 			tlas.Intersect( ray );
 			if (ray.hit.t < 10000)
 			{
-				uint32_t pixel_x = tx * 4 + x, pixel_y = ty * 4 + y;
 			#if INST_IDX_BITS == 32
 				// instance and primitive index are stored in separate fields
 				uint32_t primIdx = ray.hit.prim;
@@ -158,7 +156,7 @@ void TraceWorkerThread( uint32_t* buf, int threadIdx )
 void Tick( float delta_time_s, fenster& f, uint32_t* buf )
 {
 	// handle user input and update camera
-	bool moved = UpdateCamera( delta_time_s, f ) || frameIdx++ == 0;
+	UpdateCamera( delta_time_s, f );
 
 	// clear the screen with a debug-friendly color
 	for (int i = 0; i < SCRWIDTH * SCRHEIGHT; i++) buf[i] = 0xaaaaff;


### PR DESCRIPTION
Tinybvh now properly compiles when not using NEON or AVX but still instantiating BVH_SoA or one of the other SIMD structures.