### PR TITLE
Fix r2 and r3 using the incorrect noise variable.

### DIFF
--- a/wavefront.cl
+++ b/wavefront.cl
@@ -187,7 +187,7 @@ void kernel Shade( global float4* accumulator,
 			float2 noise0 = Noise( pixelIdx % height, pixelIdx / height, sampleIdx * 2 );
 			float2 noise1 = Noise( pixelIdx % height, pixelIdx / height, sampleIdx * 2 + 1 );
 			r0 = noise0.x, r1 = noise0.y;
-			r2 = noise0.x, r3 = noise0.y;
+			r2 = noise1.x, r3 = noise1.y;
 		}
 		else
 		{

--- a/wavefront2.cl
+++ b/wavefront2.cl
@@ -213,7 +213,7 @@ void kernel Shade( global float4* accumulator,
 			float2 noise0 = Noise( pixelIdx % height, pixelIdx / height, sampleIdx * 2 );
 			float2 noise1 = Noise( pixelIdx % height, pixelIdx / height, sampleIdx * 2 + 1 );
 			r0 = noise0.x, r1 = noise0.y;
-			r2 = noise0.x, r3 = noise0.y;
+			r2 = noise1.x, r3 = noise1.y;
 		}
 		else
 		{


### PR DESCRIPTION
For the projects tiny_bvh_gpu and tiny_bvh_gpu2, two blue noise generators are used for the first four samples of the path tracer. However, the second blue noise value was not being used. This change fixes that.