### PR TITLE
Found a bug in BVH8_CPU CombineLeafs when number of triangles in BLAS…

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -2293,6 +2293,8 @@ void BVH::Refit( const uint32_t /* unused */ )
 	aabbMin = bvhNode[0].aabbMin, aabbMax = bvhNode[0].aabbMax;
 }
 
+#define FIX_COMBINE_LEAFS 1
+
 // CombineLeafs: Collapse subtrees if the summed leaf prim count does not
 // exceed the specified number. For BVH8_CPU construction.
 void BVH::CombineLeafs( const uint32_t primCount )
@@ -2317,8 +2319,13 @@ void BVH::CombineLeafs( const uint32_t primCount )
 			}
 			else
 			{
+#if FIX_COMBINE_LEAFS 
+				if (!left.isLeaf() && left.SurfaceArea() > 0) stack[stackPtr++] = node.leftFirst;
+				if (!right.isLeaf() && right.SurfaceArea() > 0) stack[stackPtr++] = node.leftFirst + 1;
+#else
 				if (!left.isLeaf()) stack[stackPtr++] = node.leftFirst;
 				if (!right.isLeaf()) stack[stackPtr++] = node.leftFirst + 1;
+#endif
 			}
 		}
 	}

--- a/tiny_bvh_minimal_bvh8_bug.cpp
+++ b/tiny_bvh_minimal_bvh8_bug.cpp
@@ -1,0 +1,56 @@
+// Minimal example for tiny_bvh.h
+
+#define TINYBVH_IMPLEMENTATION
+#include "tiny_bvh.h"
+
+#include <cstdlib>
+#include <cstdio>
+
+#define TRIANGLE_COUNT 3
+
+tinybvh::bvhvec4 triangles[TRIANGLE_COUNT * 3]; // must be 16 byte!
+
+float uniform_rand() { return (float)rand() / (float)RAND_MAX; }
+
+int main()
+{
+	// create a scene consisting of some random small triangles
+	for (int i = 0; i < TRIANGLE_COUNT; i++)
+	{
+		// create a random triangle
+		tinybvh::bvhvec4& v0 = triangles[i * 3 + 0];
+		tinybvh::bvhvec4& v1 = triangles[i * 3 + 1];
+		tinybvh::bvhvec4& v2 = triangles[i * 3 + 2];
+		// triangle position, x/y/z = 0..1
+		float x = uniform_rand();
+		float y = uniform_rand();
+		float z = uniform_rand();
+		// set first vertex
+		v0.x = x + 0.1f * uniform_rand();
+		v0.y = y + 0.1f * uniform_rand();
+		v0.z = z + 0.1f * uniform_rand();
+		// set second vertex
+		v1.x = x + 0.1f * uniform_rand();
+		v1.y = y + 0.1f * uniform_rand();
+		v1.z = z + 0.1f * uniform_rand();
+		// set third vertex
+		v2.x = x + 0.1f * uniform_rand();
+		v2.y = y + 0.1f * uniform_rand();
+		v2.z = z + 0.1f * uniform_rand();
+	}
+
+	tinybvh::bvhvec3 O( 0.5f, 0.5f, -1 );
+	tinybvh::bvhvec3 D( 0.1f, 0, 2 );
+	tinybvh::Ray ray( O, D );
+
+	// build a BVH over the scene
+	tinybvh::BVH8_CPU bvh;
+	bvh.Build( triangles, TRIANGLE_COUNT );
+
+	// from here: play with the BVH!
+	int steps = bvh.Intersect( ray );
+	printf( "std: nearest intersection: %f (found in %i traversal steps).\n", ray.hit.t, steps );
+
+	// all done.
+	return 0;
+}


### PR DESCRIPTION
… <= 4, and proposed a simple workaround for now

When using the BVH8_CPU, I found that if you have less than 5 triangles in your BLAS, then, in the CombineLeafs function, there is an infinite loop because since there is an empty node, not marked as leaf, the Combine loops on it indefinitely. Since this kind of node is empty and has a null bound (min and max are set to zero), testing for the surface area before pushing it to the stack fixes the problem (at least for me, I tried in many test scenes of my render engine and nothing changes in the final output).

I duplicated the minimal example to make it buggy, and I added the fix with a define in tiny_bvh.h.

Hope this helps!