### PR TITLE
Fix BVH::IntersectSphere using sphere node aabb instead of current node aabb

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -2343,12 +2343,12 @@ bool BVH::IntersectSphere( const bvhvec3& pos, const float r ) const
 		{
 			// check if the leaf aabb overlaps the sphere: https://gamedev.stackexchange.com/a/156877
 			float dist2 = 0;
-			if (pos.x < bmin.x) dist2 += (bmin.x - pos.x) * (bmin.x - pos.x);
-			if (pos.x > bmax.x) dist2 += (pos.x - bmax.x) * (pos.x - bmax.x);
-			if (pos.y < bmin.y) dist2 += (bmin.y - pos.y) * (bmin.y - pos.y);
-			if (pos.y > bmax.y) dist2 += (pos.y - bmax.y) * (pos.y - bmax.y);
-			if (pos.z < bmin.z) dist2 += (bmin.z - pos.z) * (bmin.z - pos.z);
-			if (pos.z > bmax.z) dist2 += (pos.z - bmax.z) * (pos.z - bmax.z);
+			if (pos.x < node->aabbMin.x) dist2 += (node->aabbMin.x - pos.x) * (node->aabbMin.x - pos.x);
+			if (pos.x > node->aabbMax.x) dist2 += (pos.x - node->aabbMax.x) * (pos.x - node->aabbMax.x);
+			if (pos.y < node->aabbMin.y) dist2 += (node->aabbMin.y - pos.y) * (node->aabbMin.y - pos.y);
+			if (pos.y > node->aabbMax.y) dist2 += (pos.y - node->aabbMax.y) * (pos.y - node->aabbMax.y);
+			if (pos.z < node->aabbMin.z) dist2 += (node->aabbMin.z - pos.z) * (node->aabbMin.z - pos.z);
+			if (pos.z > node->aabbMax.z) dist2 += (pos.z - node->aabbMax.z) * (pos.z - node->aabbMax.z);
 			if (dist2 <= r2)
 			{
 				// tri/sphere test: https://gist.github.com/yomotsu/d845f21e2e1eb49f647f#file-gistfile1-js-L223


### PR DESCRIPTION
I had created an issue for this (https://github.com/jbikker/tinybvh/issues/143), but then decided to do a pull request because it is an easy change. 

Shouldn't the dist2 computation be wrt node->aabbMin and node->aabbMax ?
Otherwise, I think that check is not actually doing anything because pos is always inside (bmin,bmax), so dist2 is always 0 because none of the dist2 if is true, meaning the dist2 <= r2 is actually always true, so no node culling is done at all based on distance.

As a bonus, wouldn't it help more to move this culling before the isLeaf() check, so that it is not only performed in the leaf nodes, to have more aggressive pruning asap.

Don't know if anything I've said is correct or makes sense, but leaving it here in case it helps. In my case, this fix + pruning before leaves fixed performance, but I was implementing a method to gather all triangles inside the given sphere, not just a true/false check, so maybe it doesn't apply here.