### PR TITLE
fix sphere flake creation functions

### DIFF
--- a/tiny_bvh_fenster.cpp
+++ b/tiny_bvh_fenster.cpp
@@ -58,7 +58,7 @@ void sphere_flake( float x, float y, float z, float s, int d = 0 )
 	if (d < 3) sphere_flake( x + s * 1.55f, y, z, s * 0.5f, d + 1 );
 	if (d < 3) sphere_flake( x - s * 1.5f, y, z, s * 0.5f, d + 1 );
 	if (d < 3) sphere_flake( x, y + s * 1.5f, z, s * 0.5f, d + 1 );
-	if (d < 3) sphere_flake( x, x - s * 1.5f, z, s * 0.5f, d + 1 );
+	if (d < 3) sphere_flake( x, y - s * 1.5f, z, s * 0.5f, d + 1 );
 	if (d < 3) sphere_flake( x, y, z + s * 1.5f, s * 0.5f, d + 1 );
 	if (d < 3) sphere_flake( x, y, z - s * 1.5f, s * 0.5f, d + 1 );
 }
@@ -81,7 +81,7 @@ void sphere_flake_indexed( float x, float y, float z, float s, int d = 0 )
 	if (d < 3) sphere_flake_indexed( x + s * 1.55f, y, z, s * 0.5f, d + 1 );
 	if (d < 3) sphere_flake_indexed( x - s * 1.5f, y, z, s * 0.5f, d + 1 );
 	if (d < 3) sphere_flake_indexed( x, y + s * 1.5f, z, s * 0.5f, d + 1 );
-	if (d < 3) sphere_flake_indexed( x, x - s * 1.5f, z, s * 0.5f, d + 1 );
+	if (d < 3) sphere_flake_indexed( x, y - s * 1.5f, z, s * 0.5f, d + 1 );
 	if (d < 3) sphere_flake_indexed( x, y, z + s * 1.5f, s * 0.5f, d + 1 );
 	if (d < 3) sphere_flake_indexed( x, y, z - s * 1.5f, s * 0.5f, d + 1 );
 }


### PR DESCRIPTION
some spheres were in the wrong positions due to a wrong use of a variable in one of the recursive calls.
![image](https://github.com/user-attachments/assets/5636eead-cf0b-4bb7-a52a-351e8d29c10f)
![image](https://github.com/user-attachments/assets/799508fb-7500-492f-8f1c-0716268b5c63)
