### PR TITLE
Use 'aligned_alloc' function for Android NDK 28 and later.

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -234,10 +234,10 @@ inline size_t make_multiple_of( size_t x, size_t alignment ) { return (x + (alig
 #define _ALIGNED_ALLOC(alignment,size) _mm_malloc( make_multiple_of( size, alignment ), alignment );
 #define _ALIGNED_FREE(ptr) _mm_free( ptr );
 #else
-#if defined __GNUC__ && !defined __APPLE__
-#define _ALIGNED_ALLOC(alignment,size) _aligned_malloc( alignment, size );
-#else
+#if defined __APPLE__ || (defined(__ANDROID_NDK__) && defined(__NDK_MAJOR__) && (__NDK_MAJOR__ >= 28))
 #define _ALIGNED_ALLOC(alignment,size) aligned_alloc( alignment, size );
+#elif defined __GNUC__
+#define _ALIGNED_ALLOC(alignment,size) _aligned_malloc( alignment, size );
 #endif
 #define _ALIGNED_FREE(ptr) free( ptr );
 #endif


### PR DESCRIPTION
1- Motivation:

In Android NDK version 28.0.13004108 and later, the following error is raised:

```
tinybvh/tiny_bvh.h:229:25: error: use of undeclared identifier
      '_aligned_malloc'; did you mean 'aligned_alloc'?
  229 |         return size == 0 ? 0 : _aligned_malloc( 64, make_multiple_64( size ) );
      |                                ^~~~~~~~~~~~~~~
      |                                aligned_alloc
C:/Users/<ldap>/AppData/Local/Android/Sdk/ndk/28.0.13004108/toolchains/llvm/prebuilt/windows-x86_64/bin/../sysroot/usr/include/stdlib.h:93:29: 
note: 'aligned_alloc' declared here
   93 | __nodiscard void* _Nullable aligned_alloc(size_t __alignment, size_t __size) __INTRODUCED_IN(28);
      |                             ^
```

2- Suggested solution:

Use 'aligned_alloc' function that has become available in NDK version 28 and later (include/stdlib.h)


Thank you


