### PR TITLE
Use 'aligned_alloc' function with API Level 28 and later.

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -253,7 +253,7 @@ inline size_t make_multiple_of( size_t x, size_t alignment ) { return (x + (alig
 #define _ALIGNED_ALLOC(alignment,size) _mm_malloc( make_multiple_of( size, alignment ), alignment );
 #define _ALIGNED_FREE(ptr) _mm_free( ptr );
 #else
-#if defined __APPLE__ || defined __aarch64__ || (defined __ANDROID_NDK__ && defined(__NDK_MAJOR__) && (__NDK_MAJOR__ >= 28))
+#if defined __APPLE__ || defined __aarch64__ || (defined __ANDROID_API__ && (__ANDROID_API__ >= 28))
 #define _ALIGNED_ALLOC(alignment,size) aligned_alloc( alignment, make_multiple_of( size, alignment ) );
 #elif defined __GNUC__
 #ifdef __linux__


### PR DESCRIPTION
Compiling 844a2cd6911ac6bd1eddd50790110acb8e80cdff with NDK 27.2.12479018, I got the following error:
```
tinybvh/tiny_bvh.h:227:80: error: use of undeclared identifier '_aligned_malloc'; did you mean 'aligned_alloc'?
  227 | inline void* malloc64( size_t size, void* = nullptr ) { return size == 0 ? 0 : _ALIGNED_ALLOC( 64, size ); }
      |                                                                                ^
tinybvh/tiny_bvh.h:222:40: note: expanded from macro '_ALIGNED_ALLOC'
  222 | #define _ALIGNED_ALLOC(alignment,size) _aligned_malloc( alignment, size );
      |                                        ^
Android/Sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/windows-x86_64/bin/../sysroot/usr/include/stdlib.h:88:17: note: 'aligned_alloc' declared here
   88 | void* _Nullable aligned_alloc(size_t __alignment, size_t __size) __INTRODUCED_IN(28);
      |                 ^
```

After investigation, it turns out that 28 in `__INTRODUCED_IN(28)` refers to the api_level, not to `__NDK_MAJOR__` as I thought previously in ded73e6bd07e4e048749de1533374399228e9db7.

Please see https://github.com/jbikker/tinybvh/issues/173#issuecomment-2794328783 for a detailed explanation.