### PR TITLE
Mac fixes (for vanilla toolchain)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+tiny_bvh_renderer
+tiny_bvh_fenster
+tiny_bvh_pt
+tiny_bvh_speedtest
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
@@ -396,3 +400,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Mac Finder fluff
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -49,21 +49,25 @@ The library ````tiny_bvh.h```` is designed to be easy to use. Please have a look
 
 The single-source sample **ASCII test renderer** can be compiled with
 
-````g++ tiny_bvh_renderer.cpp -o tiny_bvh_renderer````
+````c++ --std=c++17 tiny_bvh_renderer.cpp -o tiny_bvh_renderer````
 
 The cross-platform fenster-based single-source **bitmap renderer** can be compiled with
 
 ````g++ -mwindows -O3 tiny_bvh_fenster.cpp -o tiny_bvh_fenster```` (on windows)
 
-````g++ -framework -O3 Cocoa tiny_bvh_fenster.cpp -o tiny_bvh_fenster```` (on macOS)
+````c++ --std=c++17 -framework Cocoa -O3 tiny_bvh_fenster.cpp -o tiny_bvh_fenster```` (on macOS)
 
 The multi-threaded **path tracing** demo can be compiled with
 
 ````g++ -mwindows -O3 tiny_bvh_pt.cpp -o tiny_bvh_pt```` (on windows)
 
+````c++ --std=c++17 -framework Cocoa -O3 tiny_bvh_pt.cpp -o tiny_bvh_pt```` (on macOS)
+
 The **performance measurement tool** can be compiled with:
 
-````g++ -mavx2 -mfma -Ofast tiny_bvh_speedtest.cpp -o tiny_bvh_speedtest````
+````g++ -mavx2 -mfma -Ofast tiny_bvh_speedtest.cpp -o tiny_bvh_speedtest```` (on windows)
+
+````c++ --std=c++17 -framework OpenCL -Ofast tiny_bvh_speedtest.cpp -o tiny_bvh_speedtest```` (on macOS)
 
 # Version 1.5.2
 

--- a/tiny_ocl.h
+++ b/tiny_ocl.h
@@ -40,7 +40,11 @@ THE SOFTWARE.
 #define TINY_OCL_H_
 
 #define CL_TARGET_OPENCL_VERSION 300
+#ifdef __APPLE__
+#include <OpenCL/cl.h>  // use with -framework OpenCL
+#else
 #include <cl.h>
+#endif
 #include <vector>
 
 // aligned memory allocation
@@ -494,8 +498,10 @@ bool CheckCL( cl_int result, const char* file, int line )
 	if (result == CL_INVALID_COMPILER_OPTIONS) FatalError( "Error: CL_INVALID_COMPILER_OPTIONS\n%s, line %i", file, line, "OpenCL error" );
 	if (result == CL_INVALID_LINKER_OPTIONS) FatalError( "Error: CL_INVALID_LINKER_OPTIONS\n%s, line %i", file, line, "OpenCL error" );
 	if (result == CL_INVALID_DEVICE_PARTITION_COUNT) FatalError( "Error: CL_INVALID_DEVICE_PARTITION_COUNT\n%s, line %i", file, line, "OpenCL error" );
+#ifndef __APPLE__
 	if (result == CL_INVALID_PIPE_SIZE) FatalError( "Error: CL_INVALID_PIPE_SIZE\n%s, line %i", file, line, "OpenCL error" );
 	if (result == CL_INVALID_DEVICE_QUEUE) FatalError( "Error: CL_INVALID_DEVICE_QUEUE\n%s, line %i", file, line, "OpenCL error" );
+#endif
 	return false;
 }
 


### PR DESCRIPTION
This is a small set of fixes so that the four example programs compile and run without issue on a MacOS machine with "Apple Silicon" (i.e., their ARM-based CPU).

I updated tiny_ocl.h to use the stock OpenCL framework, to avoid having to install additional libraries when I was building locally. (It comes with the standard toolchain install via Xcode or the Command Line Tools installer.) You might prefer to keep it the way it was, in which case I'm happy to drop that out. (Ditto anything else you'd like changed.)

Mac fixes
- On arm 64 on Mac (Apple Silicon), neon is always available, but __NEON__ isn't defined, so update the warning path for this
- Fix some clashing definitions for SIMDVEC4 etc. on this path
- Fix some v3/v4 compile issues
- Fix e0->v0 typo in BVH_SoA::Intersect
- Update tiny_ocl to work with the stock OpenCL framework on Mac.
- Update macOS compilation lines in README to work out of the box
  - On Mac g++ is by default an alias to clang, so I've renamed it to 'c++' to make it a bit clearer that you don't need a separate gcc install.
- Update .gitignore for example build results