### PR TITLE
Fix node stack overflow in BVH::Intersect()

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -2977,7 +2977,7 @@ int32_t BVH::Intersect( Ray& ray ) const
 
 template <bool posX, bool posY, bool posZ> int32_t BVH::Intersect( Ray& ray ) const
 {
-	BVHNode* node = &bvhNode[0], * stack[64];
+	BVHNode* node = &bvhNode[0], * stack[256];
 	uint32_t stackPtr = 0;
 	float cost = 0;
 	const float rox = ray.O.x * ray.rD.x;


### PR DESCRIPTION
BVH::Build() can create trees up to 256 levels deep so BVH::Intersect() needs at least that much stack to handle all possible trees.