### PR TITLE
SweepSAH: Improve multithreading

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -2676,11 +2676,11 @@ void BVH::BuildFullSweep( uint32_t nodeIdx, uint32_t depth )
 			bvhNode[n + 1].leftFirst = node.leftFirst + leftCount;
 			bvhNode[n + 1].triCount = rightCount;
 			node.leftFirst = n, node.triCount = 0;
-
-			if (leftCount >= (1 << 14) && threadedBuild)
+			
+			if (tinybvh_min( leftCount, rightCount ) >= (1 << 13) && threadedBuild)
 			{
-				std::thread t(&BuildFullSweep_, n, depth + 1, this);
-				BuildFullSweep_(n + 1, depth + 1, this);
+				std::thread t( &BuildFullSweep_, n, depth + 1, this );
+				BuildFullSweep_( n + 1, depth + 1, this );
 
 				t.join();
 				break;


### PR DESCRIPTION
You had this todo in the SweepSAH builder:
https://github.com/jbikker/tinybvh/blob/4b5b649f1193374762b0247ee20de3345633bf9b/tiny_bvh.h#L2398

I've tried a method that creates the thread and detaches it instead of joining. Then sychronization is done in the 'all done' section with a spin-wait on `atomicThreadCountPtr` (see 063b7f7303b6db39fca2b03157d9db3af1ffc34d). To my suprise build time is the same as just syncing on every recursion (I've tried many scenes), so I reverted that.

I kept the change to
* Only start a single thread per recursion and let the current thread handle the other subtree
* Adjust the heuristic to decide when we want to use a thread

The new heuristic specifically improves perf across many scenes, but tbh that might depend on CPU. I have a Ryzen 7 5700X3D 8C/16T:
```
Current: 73.90ms for  262267 triangles - 261514 nodes, SAH=74.28, rayCost=104.97
This PR: 57.96ms for  262267 triangles - 261514 nodes, SAH=74.28, rayCost=104.97
```

---

I also tested thread pool using `#pragma omp task` and build time is very similar.

I also noticed in my PathTracer that the random node order from concurrently adding the counter decreases fps from 145 to 141.
Adding a simple pass to restore depth first ordering fixes that. The atomic counter could be replaced with arithmetic, assuming 1prim per leaf to get node offsets. The depth first ordering remove the holes.