### PR TITLE
Fix Android build for API < 28 and add allocator guards

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -260,29 +260,47 @@ WARNING( "NEON not enabled in compilation." )
 // Copy of the same construct in tinyocl, in a different namespace.
 namespace tinybvh {
 inline size_t make_multiple_of( size_t x, size_t alignment ) { return (x + (alignment - 1)) & ~(alignment - 1); }
-#ifdef _MSC_VER // Visual Studio / C11
-#define ALIGNED( x ) __declspec( align( x ) )
-#define _ALIGNED_ALLOC(alignment,size) _aligned_malloc( make_multiple_of( size, alignment ), alignment );
-#define _ALIGNED_FREE(ptr) _aligned_free( ptr );
-#else // EMSCRIPTEN / gcc / clang
-#define ALIGNED( x ) __attribute__( ( aligned( x ) ) )
-#if !defined TINYBVH_NO_SIMD && (defined __x86_64__ || defined _M_X64 || defined __wasm_simd128__ || defined __wasm_relaxed_simd__)
-#include <xmmintrin.h>
-#define _ALIGNED_ALLOC(alignment,size) _mm_malloc( make_multiple_of( size, alignment ), alignment );
-#define _ALIGNED_FREE(ptr) _mm_free( ptr );
-#else
-#if defined __APPLE__ || defined __aarch64__ || (defined __ANDROID_API__ && (__ANDROID_API__ >= 28))
-#define _ALIGNED_ALLOC(alignment,size) aligned_alloc( alignment, make_multiple_of( size, alignment ) );
-#elif defined __GNUC__
-#ifdef __linux__
-#define _ALIGNED_ALLOC(alignment,size) aligned_alloc( alignment, make_multiple_of( size, alignment ) );
-#else
-#define _ALIGNED_ALLOC(alignment,size) _aligned_malloc( alignment, make_multiple_of( size, alignment ) );
+#ifndef _ALIGNED_ALLOC
+	#ifdef _MSC_VER // Visual Studio / C11
+		#define ALIGNED( x ) __declspec( align( x ) )
+		#define _ALIGNED_ALLOC(alignment,size) _aligned_malloc( make_multiple_of( size, alignment ), alignment )
+		#define _ALIGNED_FREE(ptr) _aligned_free( ptr )
+	#else // EMSCRIPTEN / gcc / clang / Android
+		#define ALIGNED( x ) __attribute__( ( aligned( x ) ) )
+		#if !defined TINYBVH_NO_SIMD && (defined __x86_64__ || defined _M_X64 || defined __wasm_simd128__ || defined __wasm_relaxed_simd__)
+			#include <xmmintrin.h>
+			#define _ALIGNED_ALLOC(alignment,size) _mm_malloc( make_multiple_of( size, alignment ), alignment )
+			#define _ALIGNED_FREE(ptr) _mm_free( ptr )
+		#elif defined(__ANDROID__)
+			#include <malloc.h>
+			#include <android/api-level.h>
+			// Android API 28+ supports aligned_alloc, but older versions (like API 24) 
+			// require memalign for aligned memory.
+			#if defined(__ANDROID_API__) && (__ANDROID_API__ >= 28) // Modern Android (9.0+)
+				#define _ALIGNED_ALLOC(alignment,size) aligned_alloc( alignment, make_multiple_of( size, alignment ) )
+			#else // Legacy Android
+				#define _ALIGNED_ALLOC(alignment,size) memalign( alignment, make_multiple_of( size, alignment ) )
+			#endif
+			#define _ALIGNED_FREE(ptr) free( ptr )
+		#elif defined(__EMSCRIPTEN__) || defined(__APPLE__) || defined(__aarch64__)
+			// Emscripten and Apple strictly follow C11 aligned_alloc
+			#define _ALIGNED_ALLOC(alignment,size) aligned_alloc( alignment, make_multiple_of( size, alignment ) )
+			#define _ALIGNED_FREE(ptr) free( ptr )
+		#elif defined(__GNUC__)
+			#ifdef __linux__
+				#define _ALIGNED_ALLOC(alignment,size) aligned_alloc( alignment, make_multiple_of( size, alignment ) )
+			#else
+				#define _ALIGNED_ALLOC(alignment,size) _aligned_malloc( alignment, make_multiple_of( size, alignment ) )
+			#endif
+			#define _ALIGNED_FREE(ptr) free( ptr )
+		#else
+			// Fallback
+			#define _ALIGNED_ALLOC(alignment,size) malloc( size )
+			#define _ALIGNED_FREE(ptr) free( ptr )
+		#endif
+	#endif
 #endif
-#endif
-#define _ALIGNED_FREE(ptr) free( ptr );
-#endif
-#endif
+
 inline void* malloc64( size_t size, void* = nullptr ) { return size == 0 ? 0 : _ALIGNED_ALLOC( 64, size ); }
 inline void* malloc4k( size_t size, void* = nullptr ) { return size == 0 ? 0 : _ALIGNED_ALLOC( 4096, size ); }
 inline void* malloc32k( size_t size, void* = nullptr ) { return size == 0 ? 0 : _ALIGNED_ALLOC( 32768, size ); }


### PR DESCRIPTION
This patch addresses a build failure on Android when targeting API levels lower than 28 (where aligned_alloc is not available in Bionic)

- Added a specific __ANDROID__ branch using memalign for legacy API support.
- Wrapped the allocation macros in #ifndef _ALIGNED_ALLOC to allow users to provide custom allocators (e.g., SDL_aligned_alloc) via prefix headers without modifying the library.

Fixes #247