### PR TITLE
Bring Your Own Threadpool

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -152,10 +152,9 @@ THE SOFTWARE.
 #define BVH_FAR	1e30f		// actual valid ieee range: 3.40282347E+38
 #define BVH_DBL_FAR 1e300	// actual valid ieee range: 1.797693134862315E+308
 
-// Threaded builds
-#ifndef MT_NO_JOBSYSTEM
-#define MT_USE_JOBSYSTEM	// use jobsystem for threading - better than std::thread.
-#define MT_JOBSYSTEM_DEPTH	9	// will generate up to 2^N tasks
+// Threaded builds: spawn subtree tasks down to this depth (up to 2^N tasks).
+#ifndef MT_SPAWN_DEPTH
+#define MT_SPAWN_DEPTH 9
 #endif
 #ifndef MT_BUILD_THRESHOLD
 #define MT_BUILD_THRESHOLD 50000 // single-threaded builds below this triangle count
@@ -209,7 +208,6 @@ THE SOFTWARE.
 #include <cstdint>
 #include <atomic> // for SBVH builds
 #include <vector>
-#include <thread> // for threaded builds
 
 // Platform-independent compile-time warnings.
 #define EMIT_COMPILER_WARNING_STRINGIFY0(x) #x
@@ -791,12 +789,56 @@ struct RayEx
 
 #endif
 
+#ifndef TINYBVH_NO_BUILTIN_POOL
+// Default build hooks: a process-wide std::thread pool (tiny_bvh_threadpool.h).
+// Define TINYBVH_NO_BUILTIN_POOL if you prefer to provide your own interface.
+void tinybvh_builtin_spawn( void (*fn)(void* payload), const void* payload, uint32_t payload_size, void* userdata );
+void tinybvh_builtin_barrier( void* userdata );
+void tinybvh_builtin_parallel_for( uint32_t n, void (*fn)(uint32_t index, void* payload), void* payload, void* userdata );
+#define TINYBVH_DEFAULT_SPAWN tinybvh_builtin_spawn
+#define TINYBVH_DEFAULT_BARRIER tinybvh_builtin_barrier
+#define TINYBVH_DEFAULT_PARALLEL_FOR tinybvh_builtin_parallel_for
+#else
+#define TINYBVH_DEFAULT_SPAWN nullptr
+#define TINYBVH_DEFAULT_BARRIER nullptr
+#define TINYBVH_DEFAULT_PARALLEL_FOR nullptr
+#endif
+
 struct BVHContext
 {
 	void* (*malloc)(size_t size, void* userdata) = malloc64;
 	void (*free)(void* ptr, void* userdata) = free64;
+	// Parallel build hooks: 'spawn' runs fn(payload-copy) asynchronously
+	void (*spawn)(void (*fn)(void* payload), const void* payload, uint32_t payload_size, void* userdata) = TINYBVH_DEFAULT_SPAWN;
+	// Wait for spawned tasks
+	void (*barrier)(void* userdata) = TINYBVH_DEFAULT_BARRIER;
+	// Runs fn(i, payload) for i in [0,n) and block for the results
+	void (*parallel_for)(uint32_t n, void (*fn)(uint32_t index, void* payload), void* payload, void* userdata) = TINYBVH_DEFAULT_PARALLEL_FOR;
 	void* userdata = nullptr;
 };
+#undef TINYBVH_DEFAULT_SPAWN
+#undef TINYBVH_DEFAULT_BARRIER
+#undef TINYBVH_DEFAULT_PARALLEL_FOR
+
+// The functions below serialize when no thread pool is available.
+
+// Spawn fn(payload) asynchronously
+inline void tinybvh_spawn( const BVHContext& ctx, void (*fn)(void*), const void* payload, uint32_t payload_size )
+{
+	if (ctx.spawn) ctx.spawn( fn, payload, payload_size, ctx.userdata );
+	else fn( (void*)payload );
+}
+// Wait for spawned tasks to finish
+inline void tinybvh_barrier( const BVHContext& ctx )
+{
+	if (ctx.barrier) ctx.barrier( ctx.userdata );
+}
+// Execute a parallel loop via the thread pool
+inline void tinybvh_parallel_for( const BVHContext& ctx, uint32_t n, void (*fn)(uint32_t, void*), void* payload )
+{
+	if (ctx.parallel_for) ctx.parallel_for( n, fn, payload, ctx.userdata );
+	else for (uint32_t i = 0; i < n; i++) fn( i, payload );
+}
 
 struct BVHBuildSettings
 {
@@ -808,7 +850,6 @@ struct BVHBuildSettings
 	bool useSIMDifavailable = true;	// set to false to use the scalar reference builder.
 };
 
-class JobSystem;
 class BVHBase
 {
 public:
@@ -881,12 +922,6 @@ protected:
 	__FORCEINLINE bool TriOccludes( const Ray& ray, const bvhvec4slice& verts, const uint32_t triIdx, const uint32_t i0, const uint32_t i1, const uint32_t i2 ) const;
 	static void PrecomputeTriangle( const bvhvec4slice& vert, const uint32_t ti0, const uint32_t ti1, const uint32_t ti2, float* T );
 	static float SA( const bvhvec3& aabbMin, const bvhvec3& aabbMax );
-#ifdef ENABLE_THREADED_BUILDS
-	// job system for parallel builds
-	JobSystem* jobStream0, * jobStream1;
-	JobSystem* GetJobStream0();
-	JobSystem* GetJobStream1();
-#endif
 };
 
 class BLASInstance;
@@ -967,6 +1002,7 @@ public:
 	void BuildHQTask( uint32_t nodeIdx, uint32_t depth, uint32_t sliceStart, uint32_t sliceEnd, uint32_t* triIdxB );
 	void BuildFullSweep( uint32_t nodeIdx = 0, uint32_t depth = 0 );
 	void BuildAVXSubtree( uint32_t nodeIdx = 0, uint32_t depth = 0 );
+	void RadixSort( uint32_t* input, uint32_t* output, uint32_t* keys, int len, int a );
 #ifdef BVH_USENEON
 	void BuildNEON( const bvhvec4* vertices, const uint32_t primCount );
 	void BuildNEON( const bvhvec4slice& vertices );
@@ -979,7 +1015,6 @@ private:
 	void PrepareHQBuild( const bvhvec4slice& vertices, const uint32_t* indices, const uint32_t prims );
 	void BuildHQ();
 	void PrepareBuild( const bvhvec4slice& vertices, const uint32_t* indices, const uint32_t primCount );
-	void RadixSort( uint32_t* input, uint32_t* output, uint32_t* keys, int len, int a );
 	void PrepareAVXBuild( const bvhvec4slice& vertices, const uint32_t* indices, const uint32_t primCount );
 	bool ClipFrag( const Fragment& orig, Fragment& newFrag, bvhvec3 bmin, bvhvec3 bmax, const uint32_t splitAxis ) const;
 	bool SplitFrag( const Fragment& orig, Fragment& left, Fragment& right, const uint32_t splitAxis, const float splitPos ) const;
@@ -1019,6 +1054,12 @@ private:
 	// Atomic counters for threaded builds
 	std::atomic<uint32_t>* atomicNewNodePtr = 0;
 	std::atomic<uint32_t>* atomicNextFrag = 0;
+	// Threaded EPOCost: recursion helper + the task that scores one spawned right subtree.
+	float EPOCostRec( uint32_t nodeIdx, uint32_t depth, float* costs, std::atomic<uint32_t>& slot );
+	static void EPOCostSubtree( void* payload );
+	// Threaded SAHCost: recursion helper + the task that scores one spawned right subtree.
+	float SAHCostRec( uint32_t nodeIdx, uint32_t depth, float* costs, std::atomic<uint32_t>& slot );
+	static void SAHCostSubtree( void* payload );
 #endif
 	// data for full sweep builder
 	uint8_t* flag = 0;
@@ -1576,12 +1617,7 @@ public:
 #endif
 #include <fstream>			// fstream
 
-// job manager includes
-#include <functional>
-#include <algorithm>
-#include <condition_variable>
-#include <mutex>
-#include <deque>
+#include <algorithm>		// for std::swap
 
 // We need quite a bit of type reinterpretation, so we'll
 // turn off the gcc warning here until the end of the file.
@@ -1756,118 +1792,6 @@ void BVHBase::CopyBasePropertiesFrom( const BVHBase& original )
 	this->aabbMin = original.aabbMin, this->aabbMax = original.aabbMax;
 }
 
-#if defined ENABLE_THREADED_BUILDS && defined MT_USE_JOBSYSTEM
-
-// Wicked job system, condensed. https://github.com/turanszkij/WickedEngine
-// Removed: Thread priority, Dispatch, graceful shutdown; not needed in TinyBVH.
-class JobSystem
-{
-public:
-	JobSystem() { Initialize(); }
-	~JobSystem()
-	{
-		if (res.numThreads == 0) return;
-		res.alive.store( false );
-		bool wake_loop = true;
-		std::thread waker( [&] { while (wake_loop) res.sleepingCondition.notify_all(); } );
-		for (auto& thread : res.threads) thread.join();
-		wake_loop = false;
-		waker.join();
-		res.jobQueue.reset();
-		res.threads.clear();
-		res.numThreads = 0;
-	}
-	struct context { std::atomic<uint32_t> counter{ 0 }; } ctx;
-	struct Job
-	{
-		std::function<void()> task;
-		inline uint32_t execute( context& ctx ) { task(); return ctx.counter.fetch_sub( 1 ); }
-	};
-	struct JobQueue
-	{
-		std::deque<Job> queue;
-		std::mutex locker;
-		inline void push_back( const Job& item ) { std::scoped_lock lock( locker ); queue.push_back( item ); }
-		inline bool pop_front( Job& item )
-		{
-			std::scoped_lock lock( locker );
-			if (queue.empty()) return false; else item = std::move( queue.front() );
-			queue.pop_front();
-			return true;
-		}
-	};
-	struct Resources
-	{
-		uint32_t numThreads = 0;
-		std::vector<std::thread> threads;
-		std::unique_ptr<JobQueue[]> jobQueue;
-		std::atomic<uint32_t> nextQueue{ 0 };
-		std::condition_variable sleepingCondition;
-		std::mutex sleepingMutex;
-		std::condition_variable waitingCondition;
-		std::mutex waitingMutex;
-		std::atomic_bool alive{ true };
-		inline void work( context& ctx, uint32_t startingQueue )
-		{
-			Job job;
-			for (uint32_t i = 0; i < numThreads; ++i) while (jobQueue[startingQueue++ % numThreads].pop_front( job ))
-				if (job.execute( ctx ) == 1) { std::unique_lock<std::mutex> lock( waitingMutex ); waitingCondition.notify_all(); }
-		}
-	} res;
-	void Initialize()
-	{
-		res.numThreads = std::thread::hardware_concurrency();
-		res.jobQueue.reset( new JobQueue[res.numThreads] );
-		res.threads.reserve( res.numThreads );
-		context& c = ctx;
-		Resources& r = res;
-		for (uint32_t threadID = 0; threadID < res.numThreads; threadID++)
-			res.threads.emplace_back( [&c, threadID, &r]
-				{	while (r.alive.load()) {
-			r.work( c, threadID );
-			std::unique_lock<std::mutex> lock( r.sleepingMutex );
-			r.sleepingCondition.wait( lock );
-		} } );
-	}
-	void Execute( const std::function<void()>& task )
-	{
-		ctx.counter.fetch_add( 1 );
-		Job job;
-		job.task = task;
-		res.jobQueue[res.nextQueue.fetch_add( 1 ) % res.numThreads].push_back( job );
-		res.sleepingCondition.notify_one();
-	}
-	void Wait()
-	{
-		if (!IsBusy()) return;
-		res.sleepingCondition.notify_all();
-		res.work( ctx, res.nextQueue.fetch_add( 1 ) % res.numThreads );
-		while (IsBusy())
-		{
-			std::unique_lock<std::mutex> lock( res.waitingMutex );
-			if (IsBusy()) res.waitingCondition.wait( lock, [this] { return !IsBusy(); } );
-		}
-	}
-	bool IsBusy() { return ctx.counter.load() > 0; }
-};
-
-JobSystem* BVHBase::GetJobStream0() {
-	static thread_local JobSystem* globalSubtreeJobs = 0;
-	if (!jobStream0) {
-		if (!globalSubtreeJobs) globalSubtreeJobs = new JobSystem();
-		jobStream0 = globalSubtreeJobs;
-	} return jobStream0;
-}
-JobSystem* BVHBase::GetJobStream1() {
-	static thread_local JobSystem* globalBinningJobs = 0;
-	if (!jobStream1) {
-		if (!globalBinningJobs) globalBinningJobs = new JobSystem();
-		jobStream1 = globalBinningJobs;
-	} return jobStream1;
-}
-
-#endif
-
 // BVH implementation
 // ----------------------------------------------------------------------------
 
@@ -1947,21 +1871,12 @@ bool BVH::Load( const char* fileName, const bvhvec4slice& vertices, const uint32
 	s.read( (char*)&fileTriCount, sizeof( uint32_t ) );
 	if (expectIndexed && fileTriCount != primCount) return false;
 	if (!expectIndexed && fileTriCount != vertices.count / 3) return false;
-	// backup pointers to JobSystems: can't deserialize pointers.
-#ifdef ENABLE_THREADED_BUILDS
-	JobSystem* subtreeBackup = jobStream0;
-	JobSystem* binningBackup = jobStream1;
-#endif
 	// all checks passed; safe to overwrite *this
 	s.read( (char*)this, sizeof( BVH ) );
 	bool fileIsIndexed = vertIdx != nullptr;
 	if (expectIndexed != fileIsIndexed) return false; // not what we expected.
 	if (blasList != nullptr || instList != nullptr) return false; // can't load/save TLAS.
 	context = ctxBackup; // can't load context; function pointers will differ.
-#ifdef ENABLE_THREADED_BUILDS
-	jobStream0 = subtreeBackup;
-	jobStream1 = binningBackup;
-#endif
 	bvhNode = (BVHNode*)AlignedAlloc( allocatedNodes * sizeof( BVHNode ) );
 	primIdx = (uint32_t*)AlignedAlloc( idxCount * sizeof( uint32_t ) );
 	fragment = 0; // no need for this in a BVH that can't be rebuilt.
@@ -2258,9 +2173,13 @@ void BVH::PrepareBuild( const bvhvec4slice& vertices, const uint32_t* indices, c
 	// all set; actual build happens in BVH::Build.
 }
 
-#ifndef MT_USE_JOBSYSTEM
-void Build_( uint32_t n, uint32_t d, BVH* bvh ) { bvh->Build( n, d ); }
-#endif
+// Helper function to build a subtree via the thread pool
+struct BVHBuildSubtreeArgs { BVH* bvh; uint32_t node, depth; };
+static void BVHBuildSubtree( void* payload )
+{
+	BVHBuildSubtreeArgs* a = (BVHBuildSubtreeArgs*)payload;
+	a->bvh->Build( a->node, a->depth );
+}
 void BVH::Build( uint32_t nodeIdx, uint32_t depth )
 {
 	// Reference builder: Binned, threaded SAH BVH builder. Not using SIMD.
@@ -2268,7 +2187,9 @@ void BVH::Build( uint32_t nodeIdx, uint32_t depth )
 	{
 		threadedBuild = false;
 	#ifdef ENABLE_THREADED_BUILDS
-		if (triCount >= MT_BUILD_THRESHOLD) threadedBuild = true, atomicNewNodePtr = new std::atomic<uint32_t>( newNodePtr );
+		// build in parallel when given a sufficiently large input
+		if (triCount >= MT_BUILD_THRESHOLD && context.spawn && context.barrier)
+			threadedBuild = true, atomicNewNodePtr = new std::atomic<uint32_t>( newNodePtr );
 	#endif
 	}
 	// subdivide root node recursively
@@ -2368,24 +2289,13 @@ void BVH::Build( uint32_t nodeIdx, uint32_t depth )
 			bvhNode[n + 1].aabbMin = bestRMin, bvhNode[n + 1].aabbMax = bestRMax;
 			bvhNode[n + 1].leftFirst = j, bvhNode[n + 1].triCount = rightCount;
 			node.leftFirst = n, node.triCount = 0;
-		#ifdef ENABLE_THREADED_BUILDS
-		#ifdef MT_USE_JOBSYSTEM
-			if (depth < MT_JOBSYSTEM_DEPTH && threadedBuild)
+			if (depth < MT_SPAWN_DEPTH && threadedBuild)
 			{
-				GetJobStream0()->Execute( [=]() { Build( n, depth + 1 ); } );
-				GetJobStream0()->Execute( [=]() { Build( n + 1, depth + 1 ); } );
+				BVHBuildSubtreeArgs a0 = { this, (uint32_t)n, depth + 1 }, a1 = { this, (uint32_t)n + 1, depth + 1 };
+				tinybvh_spawn( context, &BVHBuildSubtree, &a0, sizeof( a0 ) );
+				tinybvh_spawn( context, &BVHBuildSubtree, &a1, sizeof( a1 ) );
 				break;
 			}
-		#else
-			if (tinybvh_min( leftCount, rightCount ) >= (1 << 11) && threadedBuild)
-			{
-				std::thread t( &Build_, n, depth + 1, this );
-				Build( n + 1, depth + 1 );
-				t.join();
-				break;
-			}
-		#endif
-		#endif
 			task[taskCount++] = n + 1, nodeIdx = n;
 		}
 		// fetch subdivision task from stack
@@ -2397,9 +2307,7 @@ void BVH::Build( uint32_t nodeIdx, uint32_t depth )
 	#ifdef ENABLE_THREADED_BUILDS
 		if (threadedBuild)
 		{
-		#ifdef MT_USE_JOBSYSTEM
-			GetJobStream0()->Wait();
-		#endif
+			tinybvh_barrier( context );
 			newNodePtr = atomicNewNodePtr->load();
 			delete atomicNewNodePtr;
 			atomicNewNodePtr = 0;
@@ -2455,19 +2363,33 @@ void BVH::RadixSort( uint32_t* input, uint32_t* output, uint32_t* keys, int len,
 	}
 }
 
-#ifndef MT_USE_JOBSYSTEM
-void BuildFullSweep_( uint32_t n, uint32_t d, BVH* bvh ) { bvh->BuildFullSweep( n, d ); }
+// Helper function to build a subtree via the thread pool
+static void BVHBuildFullSweepSubtree( void* payload )
+{
+	BVHBuildSubtreeArgs* a = (BVHBuildSubtreeArgs*)payload;
+	a->bvh->BuildFullSweep( a->node, a->depth );
+}
+#ifdef ENABLE_THREADED_BUILDS
+// sort one axis' fragment keys; scheduled via the parallel_for hook.
+struct BVHRadixSortArgs { BVH* bvh; uint32_t* input[3]; uint32_t* output[3]; uint32_t* keys[3]; int len; };
+static void BVHRadixSortAxis( uint32_t a, void* payload )
+{
+	BVHRadixSortArgs* args = (BVHRadixSortArgs*)payload;
+	args->bvh->RadixSort( args->input[a], args->output[a], args->keys[a], args->len, (int)a );
+}
 #endif
 void BVH::BuildFullSweep( uint32_t nodeIdx, uint32_t depth )
 {
-	// Full-sweep SAH builder. Instead of using binning, this builder evaluates all possible split 
+	// Full-sweep SAH builder. Instead of using binning, this builder evaluates all possible split
 	// plane candidates for each axis. Works well with triangle presplitting.
 	if (depth == 0)
 	{
 		// prepare threading
 		threadedBuild = false;
 	#ifdef ENABLE_THREADED_BUILDS
-		if (triCount >= MT_BUILD_THRESHOLD) threadedBuild = true, atomicNewNodePtr = new std::atomic<uint32_t>( newNodePtr );
+		// build in parallel when given a sufficiently large input
+		if (triCount >= MT_BUILD_THRESHOLD && context.spawn && context.barrier)
+			threadedBuild = true, atomicNewNodePtr = new std::atomic<uint32_t>( newNodePtr );
 	#endif
 		// create 32-bit integer sorting key from fragment centroids
 		uint32_t* sortKey[3];
@@ -2477,15 +2399,13 @@ void BVH::BuildFullSweep( uint32_t nodeIdx, uint32_t depth )
 		// allocate data for O(N) stable partition
 		flag = (uint8_t*)AlignedAlloc( triCount );
 		for (int a = 0; a < 3; a++) sortedIdx[a] = (uint32_t*)AlignedAlloc( triCount * 4 );
-	#if defined ENABLE_THREADED_BUILDS && defined MT_USE_JOBSYSTEM
-		// sort three axii in parallel
+	#ifdef ENABLE_THREADED_BUILDS
 		uint32_t* primTmp1 = sortKey[2] + triCount, * primTmp2 = primTmp1 + triCount;
 		memcpy( primTmp1, primIdx, triCount * 4 );
 		memcpy( primTmp2, primIdx, triCount * 4 );
-		GetJobStream0()->Execute( [&]() { RadixSort( primIdx, sortedIdx[0], sortKey[0], triCount, 0 ); } );
-		GetJobStream0()->Execute( [&]() { RadixSort( primTmp1, sortedIdx[1], sortKey[1], triCount, 1 ); } );
-		GetJobStream0()->Execute( [&]() { RadixSort( primTmp2, sortedIdx[2], sortKey[2], triCount, 2 ); } );
-		GetJobStream0()->Wait();
+		BVHRadixSortArgs ra = { this, { primIdx, primTmp1, primTmp2 },
+			{ sortedIdx[0], sortedIdx[1], sortedIdx[2] }, { sortKey[0], sortKey[1], sortKey[2] }, (int)triCount };
+		tinybvh_parallel_for( context, 3, &BVHRadixSortAxis, &ra );
 	#else
 		for (uint32_t a = 0; a < 3; a++) RadixSort( primIdx, sortedIdx[a], sortKey[a], triCount, a );
 	#endif
@@ -2586,24 +2506,14 @@ void BVH::BuildFullSweep( uint32_t nodeIdx, uint32_t depth )
 			bvhNode[n + 1].leftFirst = node.leftFirst + leftCount;
 			bvhNode[n + 1].triCount = rightCount;
 			node.leftFirst = n, node.triCount = 0;
-		#ifdef ENABLE_THREADED_BUILDS
-		#ifdef MT_USE_JOBSYSTEM
-			if (threadedBuild && depth < MT_JOBSYSTEM_DEPTH)
+			if (threadedBuild && depth < MT_SPAWN_DEPTH)
 			{
-				GetJobStream0()->Execute( [=]() { BuildFullSweep( n + 1, depth + 1 ); } );
+				// spawn the right subtree, continue with the left; root barrier joins.
+				BVHBuildSubtreeArgs a = { this, (uint32_t)n + 1, depth + 1 };
+				tinybvh_spawn( context, &BVHBuildFullSweepSubtree, &a, sizeof( a ) );
 				nodeIdx = n;
 				continue;
 			}
-		#else
-			if (tinybvh_min( leftCount, rightCount ) >= (1 << 11) && threadedBuild)
-			{
-				std::thread t( &BuildFullSweep_, n, depth + 1, this );
-				BuildFullSweep( n + 1, depth + 1 );
-				t.join();
-				break;
-			}
-		#endif
-		#endif
 			// recurse
 			task[taskCount++] = n + 1, nodeIdx = n;
 		}
@@ -2616,9 +2526,7 @@ void BVH::BuildFullSweep( uint32_t nodeIdx, uint32_t depth )
 	#ifdef ENABLE_THREADED_BUILDS
 		if (threadedBuild)
 		{
-		#ifdef MT_USE_JOBSYSTEM
-			GetJobStream0()->Wait();
-		#endif
+			tinybvh_barrier( context ); // wait for all spawned subtrees
 			newNodePtr = atomicNewNodePtr->load();
 			delete atomicNewNodePtr;
 			atomicNewNodePtr = 0;
@@ -2709,7 +2617,8 @@ void BVH::PrepareHQBuild( const bvhvec4slice& vertices, const uint32_t* indices,
 #ifndef ENABLE_THREADED_BUILDS
 	threadedBuild = false;
 #else
-	if (primCount < MT_BUILD_THRESHOLD) threadedBuild = false;
+	// build in parallel when given a sufficiently large input
+	if (primCount < MT_BUILD_THRESHOLD || !context.spawn || !context.barrier) threadedBuild = false;
 #endif
 	// all set; actual build happens in BVH::BuildHQ.
 }
@@ -2747,9 +2656,13 @@ void BVH::BuildHQ()
 	Compact();
 }
 
-#ifndef MT_USE_JOBSYSTEM
-void BuildHQTask_( uint32_t n, uint32_t d, uint32_t s0, uint32_t s1, uint32_t* t, BVH* bvh ) { bvh->BuildHQTask( n, d, s0, s1, t ); }
-#endif
+// Helper function to build a subtree via the thread pool
+struct BVHBuildHQArgs { BVH* bvh; uint32_t node, depth, sliceStart, sliceEnd; uint32_t* idxTmp; };
+static void BVHBuildHQSubtree( void* payload )
+{
+	BVHBuildHQArgs* a = (BVHBuildHQArgs*)payload;
+	a->bvh->BuildHQTask( a->node, a->depth, a->sliceStart, a->sliceEnd, a->idxTmp );
+}
 void BVH::BuildHQTask( uint32_t nodeIdx, uint32_t depth, uint32_t sliceStart, uint32_t sliceEnd, uint32_t* idxTmp )
 {
 	// prepare subdivision
@@ -3009,25 +2922,15 @@ void BVH::BuildHQTask( uint32_t nodeIdx, uint32_t depth, uint32_t sliceStart, ui
 			bvhNode[rightChildIdx].leftFirst = B, bvhNode[rightChildIdx].triCount = rightCount;
 			node.leftFirst = leftChildIdx, node.triCount = 0;
 			// recurse
-		#ifdef ENABLE_THREADED_BUILDS
-		#ifdef MT_USE_JOBSYSTEM
-			if (depth < MT_JOBSYSTEM_DEPTH && threadedBuild)
+			if (depth < MT_SPAWN_DEPTH && threadedBuild)
 			{
-				// spawn a new thread for the right branch
-				GetJobStream0()->Execute( [=]() { BuildHQTask( leftChildIdx, depth + 1, sliceStart, (A + B) >> 1, idxTmp ); } );
-				GetJobStream0()->Execute( [=]() { BuildHQTask( rightChildIdx, depth + 1, (A + B) >> 1, sliceEnd, idxTmp ); } );
+				// spawn both child subtrees and return; the root barrier joins them.
+				BVHBuildHQArgs a0 = { this, (uint32_t)leftChildIdx, depth + 1, sliceStart, (A + B) >> 1, idxTmp };
+				BVHBuildHQArgs a1 = { this, (uint32_t)rightChildIdx, depth + 1, (A + B) >> 1, sliceEnd, idxTmp };
+				tinybvh_spawn( context, &BVHBuildHQSubtree, &a0, sizeof( a0 ) );
+				tinybvh_spawn( context, &BVHBuildHQSubtree, &a1, sizeof( a1 ) );
 				break;
 			}
-		#else
-			if (tinybvh_min( leftCount, rightCount ) >= (1 << 11) && threadedBuild)
-			{
-				std::thread t( &BuildHQTask_, leftChildIdx, depth + 1, sliceStart, (A + B) >> 1, idxTmp, this );
-				BuildHQTask( rightChildIdx, depth + 1, (A + B) >> 1, sliceEnd, idxTmp );
-				t.join();
-				break;
-			}
-		#endif
-		#endif
 			// proceed with left child, push right child on local stack
 			localTask[localTasks].node = rightChildIdx, localTask[localTasks].depth = depth;
 			localTask[localTasks].sliceStart = (A + B) >> 1, localTask[localTasks++].sliceEnd = sliceEnd;
@@ -3038,10 +2941,8 @@ void BVH::BuildHQTask( uint32_t nodeIdx, uint32_t depth, uint32_t sliceStart, ui
 		nodeIdx = localTask[--localTasks].node, depth = localTask[localTasks].depth;
 		sliceStart = localTask[localTasks].sliceStart, sliceEnd = localTask[localTasks].sliceEnd;
 	}
-	// all done.
-#if defined ENABLE_THREADED_BUILDS && defined MT_USE_JOBSYSTEM
-	if (depth == 0 && threadedBuild) GetJobStream0()->Wait();
-#endif
+	// all done; wait for all spawned subtrees at the root.
+	if (depth == 0 && threadedBuild) tinybvh_barrier( context );
 }
 
 float BVH::SplitCostSAH( const float rAparent, const float Aleft, const int Nleft, const float Aright, const int Nright ) const
@@ -3065,7 +2966,7 @@ int32_t BVH::PrimCount( const uint32_t nodeIdx ) const
 	return n.isLeaf() ? n.triCount : (PrimCount( n.leftFirst ) + PrimCount( n.leftFirst + 1 ));
 }
 
-#if !defined ENABLE_THREADED_BUILDS || !defined MT_USE_JOBSYSTEM
+#ifndef ENABLE_THREADED_BUILDS
 
 float BVH::SAHCost( const uint32_t nodeIdx, uint32_t )
 {
@@ -3079,25 +2980,38 @@ float BVH::SAHCost( const uint32_t nodeIdx, uint32_t )
 
 #else
 
-float BVH::SAHCost( const uint32_t nodeIdx, uint32_t depth )
+// threaded SAHCost: each spawned task scores one right subtree into a slot of the
+// node-0 call's stack scratch; the root sums the slots after the barrier.
+struct BVHSAHArgs { BVH* bvh; uint32_t node, depth; float* costs; std::atomic<uint32_t>* slot; };
+void BVH::SAHCostSubtree( void* payload )
 {
-	// Threaded SAH calculation.
-	static float costs[128];
-	static std::atomic<uint32_t> slotIdx;
+	BVHSAHArgs* a = (BVHSAHArgs*)payload;
+	a->costs[(*a->slot)++] = a->bvh->SAHCostRec( a->node, a->depth, a->costs, *a->slot );
+}
+float BVH::SAHCostRec( uint32_t nodeIdx, uint32_t depth, float* costs, std::atomic<uint32_t>& slot )
+{
 	const BVHNode& n = bvhNode[nodeIdx];
 	if (n.isLeaf()) return c_int * n.SurfaceArea() * n.triCount;
 	float cost = c_trav * n.SurfaceArea();
-	if (depth > 6) cost += SAHCost( n.leftFirst, 99 ) + SAHCost( n.leftFirst + 1, 99 ); else
+	if (depth > 6) cost += SAHCostRec( n.leftFirst, 99, costs, slot ) + SAHCostRec( n.leftFirst + 1, 99, costs, slot ); else
 	{
-		if (depth == 0) slotIdx = 0;
-		GetJobStream0()->Execute( [=]() { costs[slotIdx++] = SAHCost( n.leftFirst + 1, depth + 1 ); } );
-		cost += SAHCost( n.leftFirst, depth + 1 );
+		// spawn the right subtree into a slot, recurse the left inline.
+		BVHSAHArgs a = { this, n.leftFirst + 1, depth + 1, costs, &slot };
+		tinybvh_spawn( context, &BVH::SAHCostSubtree, &a, sizeof( a ) );
+		cost += SAHCostRec( n.leftFirst, depth + 1, costs, slot );
 	}
-	if (nodeIdx > 0) return cost;
-	// recursion ends with node 0: Finalize threaded SAH calculation
-	GetJobStream0()->Wait();
-	for (uint32_t last = slotIdx, i = 0; i < last; i++) cost += costs[i];
-	return cost / n.SurfaceArea();
+	return cost;
+}
+float BVH::SAHCost( const uint32_t nodeIdx, uint32_t depth )
+{
+	const BVHNode& n = bvhNode[nodeIdx];
+	if (n.isLeaf()) return c_int * n.SurfaceArea() * n.triCount;
+	float costs[128];
+	std::atomic<uint32_t> slot{ 0 };
+	float cost = SAHCostRec( nodeIdx, depth, costs, slot );
+	tinybvh_barrier( context );
+	for (uint32_t last = slot, i = 0; i < last; i++) cost += costs[i];
+	return nodeIdx == 0 ? (cost / n.SurfaceArea()) : cost;
 }
 
 #endif
@@ -3246,7 +3160,7 @@ float BVH::EPOArea( const uint32_t subtreeRoot, const uint32_t nodeIdx )
 	return area;
 }
 
-#if !defined ENABLE_THREADED_BUILDS || !defined MT_USE_JOBSYSTEM
+#ifndef ENABLE_THREADED_BUILDS
 
 float BVH::EPOCost( const uint32_t nodeIdx, uint32_t )
 {
@@ -3264,26 +3178,38 @@ float BVH::EPOCost( const uint32_t nodeIdx, uint32_t )
 
 #else
 
-float BVH::EPOCost( const uint32_t nodeIdx, uint32_t depth )
+// threaded EPOCost: each spawned task scores one right subtree into a slot of the
+// node-0 call's stack scratch; the root sums the slots after the barrier.
+struct BVHEPOArgs { BVH* bvh; uint32_t node, depth; float* costs; std::atomic<uint32_t>* slot; };
+void BVH::EPOCostSubtree( void* payload )
 {
-	// Determine the EPO cost of the tree, threaded version.
-	static float costs[1024];
-	static std::atomic<uint32_t> slotIdx;
+	BVHEPOArgs* a = (BVHEPOArgs*)payload;
+	a->costs[(*a->slot)++] = a->bvh->EPOCostRec( a->node, a->depth, a->costs, *a->slot );
+}
+float BVH::EPOCostRec( uint32_t nodeIdx, uint32_t depth, float* costs, std::atomic<uint32_t>& slot )
+{
 	const BVHNode& n = bvhNode[nodeIdx];
-	float cost = (n.isLeaf() ? (c_int * n.triCount) : c_trav) * EPOArea( nodeIdx ), totalArea = 0;
+	float cost = (n.isLeaf() ? (c_int * n.triCount) : c_trav) * EPOArea( nodeIdx );
 	if (!n.isLeaf())
 	{
-		if (depth > 9) cost += EPOCost( n.leftFirst, 99 ) + EPOCost( n.leftFirst + 1, 99 ); else
+		if (depth > 9) cost += EPOCostRec( n.leftFirst, 99, costs, slot ) + EPOCostRec( n.leftFirst + 1, 99, costs, slot ); else
 		{
-			if (depth == 0) slotIdx = 0;
-			GetJobStream0()->Execute( [=]() { costs[slotIdx++] = EPOCost( n.leftFirst + 1, depth + 1 ); } );
-			cost += EPOCost( n.leftFirst, depth + 1 );
+			// spawn the right subtree into a slot, recurse the left inline.
+			BVHEPOArgs a = { this, n.leftFirst + 1, depth + 1, costs, &slot };
+			tinybvh_spawn( context, &BVH::EPOCostSubtree, &a, sizeof( a ) );
+			cost += EPOCostRec( n.leftFirst, depth + 1, costs, slot );
 		}
 	}
-	if (nodeIdx > 0) return cost;
-	// recursion ends with node 0: Finalize EPO calculation
-	GetJobStream0()->Wait();
-	for (uint32_t last = slotIdx, i = 0; i < last; i++) cost += costs[i];
+	return cost;
+}
+float BVH::EPOCost( const uint32_t nodeIdx, uint32_t depth )
+{
+	float costs[1024];
+	std::atomic<uint32_t> slot{ 0 };
+	float cost = EPOCostRec( nodeIdx, depth, costs, slot );
+	tinybvh_barrier( context );
+	for (uint32_t last = slot, i = 0; i < last; i++) cost += costs[i];
+	float totalArea = 0;
 	for (uint32_t i = 0; i < triCount; i++) totalArea += PrimArea( i );
 	cost /= totalArea;
 	return (1.0f - W_EPO) * SAHCost( 0 ) + W_EPO * cost;
@@ -6718,9 +6644,30 @@ void BVH::BuildAVXBinTask( const uint32_t first, const uint32_t last, __m256* bi
 	binbox[i0] = r0, binbox[AVXBINS + i1] = r1, binbox[2 * AVXBINS + i2] = r2;
 }
 
-#ifndef MT_USE_JOBSYSTEM
-void BuildAVXSubtree_( uint32_t n, uint32_t d, BVH* bvh ) { bvh->BuildAVXSubtree( n, d ); }
-#endif
+// Helper function to build a subtree via the thread pool
+static void BVHBuildAVXSubtree( void* payload )
+{
+	BVHBuildSubtreeArgs* a = (BVHBuildSubtreeArgs*)payload;
+	a->bvh->BuildAVXSubtree( a->node, a->depth );
+}
+// bin one slice of a node's fragment range; scheduled via the parallel_for hook.
+struct BVHBuildAVXBinSliceArgs
+{
+	BVH* bvh;
+	uint32_t leftFirst, triCount, sliceSize, slices;
+	__m256* slicebinbox;				// base of slices x (3*AVXBINS) bin boxes
+	__m256* binboxOrig;
+	uint32_t* slicecount;				// base of slices x (3*AVXBINS) counts
+	__m128 nmin4, rpd4;
+};
+static void BVHBuildAVXBinSlice( uint32_t i, void* payload )
+{
+	BVHBuildAVXBinSliceArgs* a = (BVHBuildAVXBinSliceArgs*)payload;
+	const uint32_t first = a->leftFirst + a->sliceSize * i;
+	const uint32_t last = i == (a->slices - 1) ? (a->leftFirst + a->triCount) : (first + a->sliceSize);
+	a->bvh->BuildAVXBinTask( first, last, a->slicebinbox + i * 3 * AVXBINS, a->binboxOrig,
+		a->slicecount + i * 3 * AVXBINS, a->nmin4, a->rpd4 );
+}
 void BVH::BuildAVXSubtree( uint32_t nodeIdx, uint32_t depth )
 {
 	// aligned data
@@ -6729,7 +6676,7 @@ void BVH::BuildAVXSubtree( uint32_t nodeIdx, uint32_t depth )
 	ALIGNED( 64 ) uint32_t slicecount[slices][3 * AVXBINS];
 	ALIGNED( 64 ) __m256 binboxOrig[3 * AVXBINS];		// 768 bytes
 	ALIGNED( 64 ) __m256 bestLBox, bestRBox;			// 64 bytes
-	__m256* binbox = slicebinbox[0];
+	__m256* binbox = slicebinbox[0];					// slot 0 doubles as the reduce target
 	uint32_t* count = slicecount[0];
 	for (uint32_t i = 0; i < 3 * AVXBINS; i++) binboxOrig[i] = max8; // binbox initialization template
 	if (depth == 0)
@@ -6737,7 +6684,9 @@ void BVH::BuildAVXSubtree( uint32_t nodeIdx, uint32_t depth )
 		// avoid threaded building for small meshes: not efficient; build multiple in parallel instead.
 		threadedBuild = false;
 	#ifdef ENABLE_THREADED_BUILDS
-		if (triCount >= MT_BUILD_THRESHOLD) threadedBuild = true, atomicNewNodePtr = new std::atomic<uint32_t>( newNodePtr );
+		// build in parallel when given a sufficiently large input
+		if (triCount >= MT_BUILD_THRESHOLD && context.spawn && context.barrier)
+			threadedBuild = true, atomicNewNodePtr = new std::atomic<uint32_t>( newNodePtr );
 	#endif
 	}
 	// subdivide recursively
@@ -6756,31 +6705,22 @@ void BVH::BuildAVXSubtree( uint32_t nodeIdx, uint32_t depth )
 			const __m128 rpd4 = _mm_and_ps( _mm_div_ps( binmul3, d4 ), _mm_cmpneq_ps( d4, _mm_setzero_ps() ) );
 			// implementation of Section 4.1 of "Parallel Spatial Splits in Bounding Volume Hierarchies":
 			// main loop operates on two fragments to minimize dependencies and maximize ILP.
-		#if defined ENABLE_THREADED_BUILDS && defined MT_USE_JOBSYSTEM
 			if (threadedBuild && node.triCount > MT_BUILD_THRESHOLD)
 			{
-				// run binning in parallel slices
+				// bin in parallel slices, then reduce into slot 0 (binbox / count).
+				// tinybvh_parallel_for runs the slices serially if no hook is set.
 				const uint32_t sliceSize = node.triCount / slices;
-				for (int slice = 0; slice < (int)slices; slice++)
-				{
-					// calculate task start and end
-					const uint32_t first = node.leftFirst + sliceSize * slice;
-					const uint32_t last = slice == (slices - 1) ? (node.leftFirst + node.triCount) : (first + sliceSize);
-					__m256* sbb = slicebinbox[slice], * bo = binboxOrig;
-					uint32_t* sc = slicecount[slice];
-					GetJobStream1()->Execute( [=]() { BuildAVXBinTask( first, last, sbb, bo, sc, nmin4, rpd4 ); } );
-				}
-				GetJobStream1()->Wait();
-				// combine results from threads
+				BVHBuildAVXBinSliceArgs args = { this, node.leftFirst, node.triCount, sliceSize, slices,
+					slicebinbox[0], binboxOrig, slicecount[0], nmin4, rpd4 };
+				tinybvh_parallel_for( context, slices, &BVHBuildAVXBinSlice, &args );
+				// combine results from slices
 				for (int a = 0; a < 3; a++) for (int i = 0; i < AVXBINS; i++)
 					for (int ai = a * AVXBINS + i, slice = 1; slice < (int)slices; slice++) count[ai] += slicecount[slice][ai],
 						binbox[ai] = _mm256_max_ps( binbox[ai], slicebinbox[slice][ai] );
 			}
 			else
-			#else
-				// threaded binning requires use of the jobsystem.
-		#endif
-			BuildAVXBinTask( node.leftFirst, node.leftFirst + node.triCount, binbox, binboxOrig, count, nmin4, rpd4 );
+				// binning runs serially; threading comes from the subtree spawns below.
+				BuildAVXBinTask( node.leftFirst, node.leftFirst + node.triCount, binbox, binboxOrig, count, nmin4, rpd4 );
 			// calculate per-split totals
 			float splitCost = BVH_FAR;
 			const float rSAV = 1.0f / node.SurfaceArea();
@@ -6836,25 +6776,14 @@ void BVH::BuildAVXSubtree( uint32_t nodeIdx, uint32_t depth )
 			node.leftFirst = n, node.triCount = 0;
 			*(__m256*)& bvhNode[n + 1] = _mm256_xor_ps( bestRBox, signFlip8 );
 			bvhNode[n + 1].leftFirst = i, bvhNode[n + 1].triCount = rightCount;
-		#ifndef ENABLE_THREADED_BUILDS
-			task[taskCount++] = n + 1, nodeIdx = n;
-		#elif defined MT_USE_JOBSYSTEM
-			const bool spawnThreads = leftCount + rightCount > 5000 && depth < MT_JOBSYSTEM_DEPTH && threadedBuild;
+			const bool spawnThreads = leftCount + rightCount > 5000 && depth < MT_SPAWN_DEPTH && threadedBuild;
 			if (!spawnThreads) task[taskCount++] = n + 1, nodeIdx = n; else
 			{
-				GetJobStream0()->Execute( [=]() { BuildAVXSubtree( n + 1, depth + 1 ); } );
+				// spawn the right subtree, continue with the left; root barrier joins.
+				BVHBuildSubtreeArgs a = { this, n + 1, depth + 1 };
+				tinybvh_spawn( context, &BVHBuildAVXSubtree, &a, sizeof( a ) );
 				nodeIdx = n;
 			}
-		#else
-			if (leftCount + rightCount > 2000 && depth < 5 && threadedBuild)
-			{
-				std::thread t1( &BuildAVXSubtree_, n, depth + 1, this );
-				BuildAVXSubtree( n + 1, depth + 1 );
-				t1.join();
-				break;
-			}
-			task[taskCount++] = n + 1, nodeIdx = n;
-		#endif
 		}
 		// fetch subdivision task from stack
 		if (taskCount == 0) break;
@@ -6863,13 +6792,10 @@ void BVH::BuildAVXSubtree( uint32_t nodeIdx, uint32_t depth )
 	// all done.
 	if (depth == 0)
 	{
-		// wait for all threads to complete.
 	#ifdef ENABLE_THREADED_BUILDS
 		if (threadedBuild)
 		{
-		#ifdef MT_USE_JOBSYSTEM
-			GetJobStream0()->Wait();
-		#endif
+			tinybvh_barrier( context ); // wait for all spawned subtrees
 			newNodePtr = atomicNewNodePtr->load();
 			delete atomicNewNodePtr;
 			atomicNewNodePtr = 0;
@@ -8261,9 +8187,13 @@ void BVH_Double::PrepareBuild( const bvhdbl3* vertices, const uint32_t* indices,
 	// all set; actual build happens in BVH_Double::Build.
 }
 
-#ifndef MT_USE_JOBSYSTEM
-void BuildDouble_( uint64_t nodeIdx, uint32_t depth, BVH_Double* bvh ) { bvh->Build( nodeIdx, depth ); }
-#endif
+// Helper function to build a subtree via the thread pool
+struct BVHDoubleBuildSubtreeArgs { BVH_Double* bvh; uint64_t node; uint32_t depth; };
+static void BVHDoubleBuildSubtree( void* payload )
+{
+	BVHDoubleBuildSubtreeArgs* a = (BVHDoubleBuildSubtreeArgs*)payload;
+	a->bvh->Build( a->node, a->depth );
+}
 void BVH_Double::Build( uint64_t nodeIdx, uint32_t depth )
 {
 	// avoid threaded building for small meshes: not efficient; build multiple in parallel instead.
@@ -8271,7 +8201,9 @@ void BVH_Double::Build( uint64_t nodeIdx, uint32_t depth )
 	{
 		threadedBuild = false;
 	#ifdef ENABLE_THREADED_BUILDS
-		if (triCount >= MT_BUILD_THRESHOLD) threadedBuild = true, atomicNewNodePtr = new std::atomic<uint64_t>( newNodePtr );
+		// build in parallel when given a sufficiently large input
+		if (triCount >= MT_BUILD_THRESHOLD && context.spawn && context.barrier)
+			threadedBuild = true, atomicNewNodePtr = new std::atomic<uint64_t>( newNodePtr );
 	#endif
 	}
 	// subdivide root node recursively
@@ -8367,24 +8299,14 @@ void BVH_Double::Build( uint64_t nodeIdx, uint32_t depth )
 			bvhNode[n + 1].aabbMin = bestRMin, bvhNode[n + 1].aabbMax = bestRMax;
 			bvhNode[n + 1].leftFirst = j, bvhNode[n + 1].triCount = rightCount;
 			node.leftFirst = n, node.triCount = 0;
-		#ifdef ENABLE_THREADED_BUILDS
-		#ifdef MT_USE_JOBSYSTEM
-			if (depth < MT_JOBSYSTEM_DEPTH && threadedBuild)
+			if (depth < MT_SPAWN_DEPTH && threadedBuild)
 			{
-				GetJobStream0()->Execute( [=]() { Build( n, depth + 1 ); } );
-				GetJobStream0()->Execute( [=]() { Build( n + 1, depth + 1 ); } );
+				// spawn both child subtrees and return; the root barrier joins them.
+				BVHDoubleBuildSubtreeArgs a0 = { this, n, depth + 1 }, a1 = { this, n + 1, depth + 1 };
+				tinybvh_spawn( context, &BVHDoubleBuildSubtree, &a0, sizeof( a0 ) );
+				tinybvh_spawn( context, &BVHDoubleBuildSubtree, &a1, sizeof( a1 ) );
 				break;
 			}
-		#else
-			if (threadedBuild && (leftCount >= (1 << 11) || rightCount >= (1 << 11)))
-			{
-				std::thread t( &BuildDouble_, n, depth + 1, this );
-				Build( n + 1, depth + 1 );
-				t.join();
-				break;
-			}
-		#endif
-		#endif
 			// recurse
 			task[taskCount++] = n + 1, nodeIdx = n;
 		}
@@ -8396,9 +8318,7 @@ void BVH_Double::Build( uint64_t nodeIdx, uint32_t depth )
 	#ifdef ENABLE_THREADED_BUILDS
 		if (threadedBuild)
 		{
-		#ifdef MT_USE_JOBSYSTEM
-			GetJobStream0()->Wait();
-		#endif
+			tinybvh_barrier( context ); // wait for all spawned subtrees
 			newNodePtr = atomicNewNodePtr->load();
 			delete atomicNewNodePtr;
 			atomicNewNodePtr = 0;
@@ -9156,6 +9076,12 @@ void BVH_Verbose::MergeSubtree( const uint32_t nodeIdx, uint32_t* newIdx, uint32
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
+
+// built-in std::thread pool backing the default BVHContext hooks; define
+// TINYBVH_NO_BUILTIN_POOL to leave it out (builds are serial unless you hook one).
+#ifndef TINYBVH_NO_BUILTIN_POOL
+#include "tiny_bvh_threadpool.h"
 #endif
 
 #endif // TINYBVH_IMPLEMENTATION

--- a/tiny_bvh_threadpool.h
+++ b/tiny_bvh_threadpool.h
@@ -1,0 +1,219 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2024-2026, Jacco Bikker / Breda University of Applied Sciences.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/*
+	tiny_bvh_threadpool.h - default parallel build backend for tiny_bvh.h.
+
+	Implements BVHContext's spawn / barrier / parallel_for hooks on the bundled
+	job system. Included automatically from the TINYBVH_IMPLEMENTATION translation
+	unit unless TINYBVH_NO_BUILTIN_POOL is set.
+*/
+
+#pragma once
+
+#include <atomic>
+#include <cassert>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace tinybvh {
+
+// Wicked job system, condensed. https://github.com/turanszkij/WickedEngine
+// Removed: Thread priority, Dispatch, graceful shutdown; not needed in TinyBVH.
+// A task is a raw function pointer plus an inline payload copy: pool-agnostic, with
+// no per-task allocation.
+class JobSystem
+{
+public:
+	JobSystem() { Initialize(); }
+	~JobSystem()
+	{
+		if (res.numThreads == 0) return;
+		res.alive.store( false );
+		bool wake_loop = true;
+		std::thread waker( [&] { while (wake_loop) res.sleepingCondition.notify_all(); } );
+		for (auto& thread : res.threads) thread.join();
+		wake_loop = false;
+		waker.join();
+		res.jobQueue.reset();
+		res.threads.clear();
+		res.numThreads = 0;
+	}
+	struct context { std::atomic<uint32_t> counter{ 0 }; } ctx;
+	static const uint32_t JOB_PAYLOAD_MAX = 64; // builder payloads are <= 32B, + spawn header
+	struct Job
+	{
+		void (*fn)(void*) = nullptr;
+		alignas( 16 ) uint8_t payload[JOB_PAYLOAD_MAX];	// inline copy; scheduling never allocates
+		inline uint32_t execute( context& ctx )
+		{
+			fn( payload );
+			return ctx.counter.fetch_sub( 1 );
+		}
+	};
+	struct JobQueue
+	{
+		std::deque<Job> queue;
+		std::mutex locker;
+		inline void push_back( const Job& item ) { std::scoped_lock lock( locker ); queue.push_back( item ); }
+		inline bool pop_front( Job& item )
+		{
+			std::scoped_lock lock( locker );
+			if (queue.empty()) return false; else item = std::move( queue.front() );
+			queue.pop_front();
+			return true;
+		}
+	};
+	struct Resources
+	{
+		uint32_t numThreads = 0;
+		std::vector<std::thread> threads;
+		std::unique_ptr<JobQueue[]> jobQueue;
+		std::atomic<uint32_t> nextQueue{ 0 };
+		std::condition_variable sleepingCondition;
+		std::mutex sleepingMutex;
+		std::condition_variable waitingCondition;
+		std::mutex waitingMutex;
+		std::atomic_bool alive{ true };
+		inline void work( context& ctx, uint32_t startingQueue )
+		{
+			Job job;
+			for (uint32_t i = 0; i < numThreads; ++i) while (jobQueue[startingQueue++ % numThreads].pop_front( job ))
+				if (job.execute( ctx ) == 1) { std::unique_lock<std::mutex> lock( waitingMutex ); waitingCondition.notify_all(); }
+		}
+	} res;
+	void Initialize()
+	{
+		res.numThreads = std::thread::hardware_concurrency();
+		res.jobQueue.reset( new JobQueue[res.numThreads] );
+		res.threads.reserve( res.numThreads );
+		context& c = ctx;
+		Resources& r = res;
+		for (uint32_t threadID = 0; threadID < res.numThreads; threadID++)
+			res.threads.emplace_back( [&c, threadID, &r]
+				{	while (r.alive.load()) {
+			r.work( c, threadID );
+			std::unique_lock<std::mutex> lock( r.sleepingMutex );
+			r.sleepingCondition.wait( lock );
+		} } );
+	}
+	void Execute( void (*fn)(void*), const void* payload, uint32_t size )
+	{
+		assert( size <= JOB_PAYLOAD_MAX );
+		ctx.counter.fetch_add( 1 );
+		Job job;
+		job.fn = fn;
+		memcpy( job.payload, payload, size );
+		res.jobQueue[res.nextQueue.fetch_add( 1 ) % res.numThreads].push_back( job );
+		res.sleepingCondition.notify_one();
+	}
+	void Wait()
+	{
+		if (!IsBusy()) return;
+		res.sleepingCondition.notify_all();
+		res.work( ctx, res.nextQueue.fetch_add( 1 ) % res.numThreads );
+		while (IsBusy())
+		{
+			std::unique_lock<std::mutex> lock( res.waitingMutex );
+			if (IsBusy()) res.waitingCondition.wait( lock, [this] { return !IsBusy(); } );
+		}
+	}
+	bool IsBusy() { return ctx.counter.load() > 0; }
+};
+
+// A build uses two job systems: 'subtree' for recursive fork/join (spawn/barrier)
+// and 'binning' for the AVX builder's scoped leaf fan-out (parallel_for). One pair
+// per host thread; 'binning' is created on demand (the scalar builders never bin).
+struct PoolPair
+{
+	JobSystem subtree;
+	std::unique_ptr<JobSystem> binningJobs;
+	std::mutex binningMutex;
+	JobSystem& binning()
+	{
+		std::scoped_lock lock( binningMutex );
+		if (!binningJobs) binningJobs = std::make_unique<JobSystem>();
+		return *binningJobs;
+	}
+};
+
+// One pair per host thread, owned by that thread and freed (its threads joined) at thread exit.
+static thread_local PoolPair* tinybvh_tl_pair = nullptr;
+static PoolPair* tinybvh_pool_pair()
+{
+	static thread_local std::unique_ptr<PoolPair> owned;
+	if (!tinybvh_tl_pair) tinybvh_tl_pair = (owned = std::make_unique<PoolPair>()).get();
+	return tinybvh_tl_pair;
+}
+
+// Spawned tasks run [pair][fn] ahead of the payload: the worker adopts 'pair' so its
+// nested spawns reuse this host's pools. Keeps the pool/TLS logic out of JobSystem.
+struct BVHSpawnEnvelope { PoolPair* pair; void (*fn)(void*); };
+static void tinybvh_spawn_task( void* blob )
+{
+	BVHSpawnEnvelope* e = (BVHSpawnEnvelope*)blob;
+	tinybvh_tl_pair = e->pair;
+	e->fn( (uint8_t*)blob + sizeof( BVHSpawnEnvelope ) );
+}
+
+// Default BVHContext hooks (declared in tiny_bvh.h); userdata is unused.
+void tinybvh_builtin_spawn( void (*fn)(void*), const void* payload, uint32_t payload_size, void* )
+{
+	// pack [pair][fn][payload]; Execute copies it inline (the caller's frame may unwind).
+	PoolPair* pair = tinybvh_pool_pair();
+	alignas( 16 ) uint8_t blob[JobSystem::JOB_PAYLOAD_MAX];
+	BVHSpawnEnvelope* e = (BVHSpawnEnvelope*)blob;
+	e->pair = pair, e->fn = fn;
+	memcpy( blob + sizeof( BVHSpawnEnvelope ), payload, payload_size );
+	pair->subtree.Execute( &tinybvh_spawn_task, blob, sizeof( BVHSpawnEnvelope ) + payload_size );
+}
+void tinybvh_builtin_barrier( void* )
+{
+	tinybvh_pool_pair()->subtree.Wait();
+}
+struct BVHParallelForArgs { void (*fn)(uint32_t, void*); uint32_t index; void* payload; };
+static void tinybvh_parallel_for_task( void* payload )
+{
+	BVHParallelForArgs* a = (BVHParallelForArgs*)payload;
+	a->fn( a->index, a->payload );
+}
+void tinybvh_builtin_parallel_for( uint32_t n, void (*fn)(uint32_t, void*), void* payload, void* )
+{
+	if (n == 0) return;
+	JobSystem& jobs = tinybvh_pool_pair()->binning();
+	for (uint32_t i = 0; i < n; i++)
+	{
+		BVHParallelForArgs a = { fn, i, payload };
+		jobs.Execute( &tinybvh_parallel_for_task, &a, sizeof( a ) );
+	}
+	jobs.Wait();
+}
+
+} // namespace tinybvh


### PR DESCRIPTION
TinyBVH previously provided a "Bring Your Own Vector Types" feature to simplify integration into existing codebases. In contrast, it hardcoded its own thread pool, for which existing codebases will typically already have an solution in place (e.g., TBB, nanothread, etc.).

This commit introduces an analogous "Bring Your Own Threadpool" abstraction that adds optional hooks to BVHContext.

- `spawn`: fire-and-forget recursive fork
- `barrier`: wait for forked work to complete
- `parallel_for`: a parallel loop that blocks until results are ready

The commit adapts all builders (``Build``, ``BuildFullSweep``, ``BuildHQ``, ``BuildAVX``, ``BVH_Double``) to use these hooks. A separate file ``tiny_bvh_threadpool.h`` contains the Wicked job system (condensed, with allocation-free task dispatch) wrapped behind the new abstraction. Defining ``TINYBVH_NO_BUILTIN_POOL`` causes that header to not be included, in which case users should install custom hooks (or the build will run single threaded).