### PR TITLE
Fix undefined reference when using BVH4_GPU_COMPRESSED_TRIS.

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -5422,8 +5422,8 @@ void BVH4_GPU::ConvertFrom( const MBVH<4>& original, bool compact )
 				else
 					ti0 = t * 3, ti1 = t * 3 + 1, ti2 = t * 3 + 2;
 			#ifdef BVH4_GPU_COMPRESSED_TRIS
-				PrecomputeTriangle( verts, ti0, ti1, ti2, (float*)&bvh4Alt[newAlt4Ptr] );
-				bvh4Alt[newAlt4Ptr + 3] = bvhvec4( 0, 0, 0, *(float*)&t );
+				PrecomputeTriangle( bvh4.bvh.verts, ti0, ti1, ti2, (float*)&bvh4Data[newAlt4Ptr] );
+				bvh4Data[newAlt4Ptr + 3] = bvhvec4( 0, 0, 0, *(float*)&t );
 				newAlt4Ptr += 4;
 			#else
 				bvhvec4 v0 = bvh4.bvh.verts[ti0];


### PR DESCRIPTION
Similar to #265 but with `BVH4_GPU`.

> Seems `verts` got lost in refactor in `BVH8_CWBVH` and TinyBVH would fail to compile when using `CWBVH_COMPRESSED_TRIS`.
> 
> Works well now with my port of the provided OpenCL CWBVH traversal kernel.
