### PR TITLE
Fix TLAS ray state and degenerate reciprocal directions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ enable_testing()
 add_executable(tiny_bvh_minimal examples/tiny_bvh_minimal.cpp)
 add_executable(tiny_bvh_renderer examples/tiny_bvh_renderer.cpp)
 add_executable(tiny_bvh_double_test examples/tiny_bvh_double_test.cpp)
+add_executable(tiny_bvh_tlas_state_test examples/tiny_bvh_tlas_state_test.cpp)
 if (NOT EMSCRIPTEN) # EMSCRIPTEN doesn't render anything by default (you would need WebGL/WebGPU)
 	add_executable(tiny_bvh_fenster examples/tiny_bvh_fenster.cpp)
 	target_include_directories(tiny_bvh_fenster PRIVATE ${CMAKE_CURRENT_LIST_DIR})
@@ -47,6 +48,7 @@ endif()
 target_include_directories(tiny_bvh_minimal PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_include_directories(tiny_bvh_renderer PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_include_directories(tiny_bvh_double_test PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(tiny_bvh_tlas_state_test PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 if (NOT MSVC)
 	# Produce debug symbols and set optimization level
@@ -95,6 +97,9 @@ if (NOT MSVC)
 
 	target_compile_options(tiny_bvh_double_test PRIVATE ${common_cxx_flags})
 	target_link_options(tiny_bvh_double_test PRIVATE ${common_link_flags})
+
+	target_compile_options(tiny_bvh_tlas_state_test PRIVATE ${common_cxx_flags})
+	target_link_options(tiny_bvh_tlas_state_test PRIVATE ${common_link_flags})
 
 	# No openmp support in default compiler
 	# set(tiny_bvh_speedtest_cxx_flags ${common_cxx_flags})
@@ -157,3 +162,4 @@ endif()
 
 add_test(NAME "examples/tiny_bvh_minimal" COMMAND tiny_bvh_minimal)
 add_test(NAME "examples/tiny_bvh_double_test" COMMAND tiny_bvh_double_test)
+add_test(NAME "examples/tiny_bvh_tlas_state_test" COMMAND tiny_bvh_tlas_state_test)

--- a/examples/tiny_bvh_tlas_state_test.cpp
+++ b/examples/tiny_bvh_tlas_state_test.cpp
@@ -1,0 +1,111 @@
+// Regression tests for state propagation from a TLAS to a custom BLAS.
+//
+// Float and double variants intentionally perform the same setup and checks:
+// a ray with mask 2 skips instance 0, selects instance 1, and must reach the
+// BLAS callback with the selected instance ID, mask, and tmax. Each variant
+// checks both occlusion and intersection traversal; the latter also verifies
+// that the BLAS hit record is returned to the caller.
+
+#define TINYBVH_IMPLEMENTATION
+#define TINYBVH_NO_SIMD
+#include "tiny_bvh.h"
+#include <cstdio>
+
+using namespace tinybvh;
+
+static bool floatStateValid = false, doubleStateValid = false;
+static int floatCalls = 0, doubleCalls = 0;
+
+static void FloatAABB( const unsigned, bvhvec3& bmin, bvhvec3& bmax )
+{
+	bmin = bvhvec3( -1, -1, 4 );
+	bmax = bvhvec3( 1, 1, 6 );
+}
+
+static void DoubleAABB( const uint64_t, bvhdbl3& bmin, bvhdbl3& bmax )
+{
+	bmin = bvhdbl3( -1, -1, 4 );
+	bmax = bvhdbl3( 1, 1, 6 );
+}
+
+static bool FloatOccludes( const Ray& ray, const unsigned )
+{
+	floatCalls++;
+	return floatStateValid = ray.instIdx == (1u << INST_IDX_SHFT) && ray.mask == 2 && ray.hit.t == 3.0f;
+}
+
+static bool DoubleOccludes( const RayEx& ray, const uint64_t )
+{
+	doubleCalls++;
+	return doubleStateValid = ray.instIdx == 1 && ray.mask == 2 && ray.hit.t == 3.0;
+}
+
+static bool FloatIntersects( Ray& ray, const unsigned )
+{
+	floatCalls++;
+	if (!(floatStateValid = ray.instIdx == (1u << INST_IDX_SHFT) && ray.mask == 2 && ray.hit.t == 3.0f)) return false;
+	ray.hit.t = 2.0f;
+	return true;
+}
+
+static bool DoubleIntersects( RayEx& ray, const uint64_t )
+{
+	doubleCalls++;
+	if (!(doubleStateValid = ray.instIdx == 1 && ray.mask == 2 && ray.hit.t == 3.0)) return false;
+	ray.hit.t = 2.0;
+	return true;
+}
+
+static bool TestFloat()
+{
+	BVH blas, tlas;
+	blas.Build( &FloatAABB, 1 );
+	blas.customIsOccluded = &FloatOccludes;
+	blas.customIntersect = &FloatIntersects;
+	BVHBase* blases[] = { &blas };
+	BLASInstance instances[] = { BLASInstance( 0 ), BLASInstance( 0 ) };
+	instances[0].mask = 1;
+	instances[1].mask = 2;
+	tlas.Build( instances, 2, blases, 1 );
+
+	floatCalls = 0;
+	floatStateValid = false;
+	const Ray shadow( bvhvec3( 0, 0, 0 ), bvhvec3( 0, 0, 1 ), 3.0f, 2 );
+	if (!tlas.IsOccluded( shadow ) || floatCalls != 1 || !floatStateValid) return false;
+	floatCalls = 0;
+	floatStateValid = false;
+	Ray probe( bvhvec3( 0, 0, 0 ), bvhvec3( 0, 0, 1 ), 3.0f, 2 );
+	tlas.Intersect( probe );
+	return floatCalls == 1 && floatStateValid && probe.hit.t == 2.0f;
+}
+
+static bool TestDouble()
+{
+	BVH_Double blas, tlas;
+	blas.Build( &DoubleAABB, 1 );
+	blas.customIsOccluded = &DoubleOccludes;
+	blas.customIntersect = &DoubleIntersects;
+	BVH_Double* blases[] = { &blas };
+	BLASInstanceEx instances[] = { BLASInstanceEx( 0 ), BLASInstanceEx( 0 ) };
+	instances[0].mask = 1;
+	instances[1].mask = 2;
+	tlas.Build( instances, 2, blases, 1 );
+
+	doubleCalls = 0;
+	doubleStateValid = false;
+	const RayEx shadow( bvhdbl3( 0, 0, 0 ), bvhdbl3( 0, 0, 1 ), 3.0, 2 );
+	if (!tlas.IsOccluded( shadow ) || doubleCalls != 1 || !doubleStateValid) return false;
+	doubleCalls = 0;
+	doubleStateValid = false;
+	RayEx probe( bvhdbl3( 0, 0, 0 ), bvhdbl3( 0, 0, 1 ), 3.0, 2 );
+	tlas.Intersect( probe );
+	return doubleCalls == 1 && doubleStateValid && probe.hit.t == 2.0;
+}
+
+int main()
+{
+	if (!TestFloat()) { printf( "FAIL: float TLAS state propagation.\n" ); return 1; }
+	if (!TestDouble()) { printf( "FAIL: double TLAS state propagation.\n" ); return 1; }
+	printf( "TLAS state tests passed.\n" );
+	return 0;
+}

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -492,6 +492,12 @@ TINYBVH_FORCEINLINE bool tinybvh_isfinite( float f )
 	std::memcpy( &i, &f, sizeof( i ) );
 	return (i & 0x7F800000) != 0x7F800000; // ieee-754: finite if not all exponent bits are 1.
 }
+TINYBVH_FORCEINLINE bool tinybvh_isfinite( double f )
+{
+	uint64_t i;
+	std::memcpy( &i, &f, sizeof( i ) );
+	return (i & 0x7FF0000000000000ull) != 0x7FF0000000000000ull; // ieee-754
+}
 TINYBVH_FORCEINLINE bool tinybvh_isnan( float f )
 {
 	uint32_t i;
@@ -509,6 +515,12 @@ TINYBVH_FORCEINLINE float tinybvh_safercp( const float x )
 	// Madmann91's version
 	return fabs( x ) <= FLT_EPSILON ? copysign( 3.402823466e+38F /* FLT_MAX */, x ) : (1.0f / x );
 #endif
+}
+TINYBVH_FORCEINLINE double tinybvh_safercp( const double x )
+{
+	double r = 1 / x;
+	if (!tinybvh_isfinite( r )) r = copysign( 1.7976931348623158e+308 /* DBL_MAX */, x );
+	return r;
 }
 TINYBVH_FORCEINLINE bvhvec3 tinybvh_safercp( const bvhvec3 a ) { return bvhvec3( tinybvh_safercp( a.x ), tinybvh_safercp( a.y ), tinybvh_safercp( a.z ) ); }
 TINYBVH_FORCEINLINE bvhvec3 tinybvh_rcp( const bvhvec3 a ) { return tinybvh_safercp( a ); /* bvhvec3( 1.0f / a.x, 1.0f / a.y, 1.0f / a.z ); */ }
@@ -656,6 +668,8 @@ TINYBVH_FORCEINLINE bvhdbl3 tinybvh_normalize( const bvhdbl3& a )
 	double l = tinybvh_length( a ), rl = l == 0 ? 0 : (1.0 / l);
 	return a * rl;
 }
+TINYBVH_FORCEINLINE bvhdbl3 tinybvh_safercp( const bvhdbl3 a ) { return bvhdbl3( tinybvh_safercp( a.x ), tinybvh_safercp( a.y ), tinybvh_safercp( a.z ) ); }
+TINYBVH_FORCEINLINE bvhdbl3 tinybvh_rcp( const bvhdbl3 a ) { return tinybvh_safercp( a ); }
 inline bvhdbl3 tinybvh_transform_point( const bvhdbl3& v, const double* T )
 {
 	const bvhdbl3 res(
@@ -824,7 +838,7 @@ struct RayEx
 		O = origin, D = direction;
 		double rl = 1.0 / sqrt( D.x * D.x + D.y * D.y + D.z * D.z );
 		D.x *= rl, D.y *= rl, D.z *= rl;
-		rD.x = 1.0 / D.x, rD.y = 1.0 / D.y, rD.z = 1.0 / D.z;
+		rD = tinybvh_rcp( D );
 		hit.u = hit.v = 0, hit.t = tmax;
 		instIdx = 0;
 		mask = rayMask & RAY_MASK_INTERSECT_ALL;
@@ -3739,6 +3753,7 @@ template <bool posX, bool posY, bool posZ> int32_t BVH::IntersectTLAS( Ray& ray 
 				tmpRay.O = tinybvh_transform_point( ray.O, inst.invTransform );
 				tmpRay.D = tinybvh_transform_vector( ray.D, inst.invTransform );
 				tmpRay.instIdx = instIdx << (32 - INST_IDX_BITS);
+				tmpRay.mask = ray.mask;
 				tmpRay.hit = ray.hit;
 				tmpRay.rD = tinybvh_rcp( tmpRay.D );
 				// 2. Traverse BLAS with the transformed ray
@@ -3878,14 +3893,17 @@ template <bool posX, bool posY, bool posZ> bool BVH::IsOccludedTLAS( const Ray& 
 			for (uint32_t i = 0; i < node->triCount; i++)
 			{
 				// BLAS traversal
-				BLASInstance& inst = instList[primIdx[node->leftFirst + i]];
+				const uint32_t instIdx = primIdx[node->leftFirst + i];
+				BLASInstance& inst = instList[instIdx];
 				const BVHBase* blas = blasList[inst.blasIdx];
 				// Check if the ray should intersect this BLAS Instance, otherwise skip it
 				if (!(inst.mask & ray.mask)) continue;
 				// 1. Transform ray with the inverse of the instance transform
 				tmpRay.O = tinybvh_transform_point( ray.O, inst.invTransform );
 				tmpRay.D = tinybvh_transform_vector( ray.D, inst.invTransform );
-				tmpRay.hit.t = ray.hit.t;
+				tmpRay.instIdx = instIdx << INST_IDX_SHFT;
+				tmpRay.mask = ray.mask;
+				tmpRay.hit = ray.hit;
 				tmpRay.rD = tinybvh_rcp( tmpRay.D );
 				// 2. Traverse BLAS with the transformed ray
 				assert( blas->layout == LAYOUT_BVH || blas->layout == LAYOUT_BVH8_AVX2 || blas->layout == LAYOUT_BVH4_CPU );
@@ -9392,10 +9410,11 @@ int32_t BVH_Double::IntersectTLAS( RayEx& ray ) const
 				// 1. Transform ray with the inverse of the instance transform
 				tmp.O = tinybvh_transform_point( ray.O, inst.invTransform );
 				tmp.D = tinybvh_transform_vector( ray.D, inst.invTransform );
-				tmp.rD = bvhdbl3( 1.0 / tmp.D.x, 1.0 / tmp.D.y, 1.0 / tmp.D.z );
 				tmp.hit = ray.hit;
-				// 2. Traverse BLAS with the transformed ray
 				tmp.instIdx = instIdx;
+				tmp.mask = ray.mask;
+				tmp.rD = tinybvh_rcp( tmp.D );
+				// 2. Traverse BLAS with the transformed ray
 				cost += blas->Intersect( tmp );
 				// 3. Restore ray
 				ray.hit = tmp.hit;
@@ -9485,15 +9504,17 @@ bool BVH_Double::IsOccludedTLAS( const RayEx& ray ) const
 			for (uint32_t i = 0; i < node->triCount; i++)
 			{
 				// BLAS traversal
-				BLASInstanceEx& inst = instList[primIdx[node->leftFirst + i]];
+				const uint64_t instIdx = primIdx[node->leftFirst + i];
+				BLASInstanceEx& inst = instList[instIdx];
 				if (!(inst.mask & ray.mask)) continue;
 				BVH_Double* blas = blasList[inst.blasIdx];
 				// 1. Transform ray with the inverse of the instance transform
 				tmp.O = tinybvh_transform_point( ray.O, inst.invTransform );
 				tmp.D = tinybvh_transform_vector( ray.D, inst.invTransform );
-				tmp.rD.x = tmp.D.x > 1e-24 ? (1.0 / tmp.D.x) : (tmp.D.x < -1e-24 ? (1.0 / tmp.D.x) : BVH_DBL_FAR);
-				tmp.rD.y = tmp.D.y > 1e-24 ? (1.0 / tmp.D.y) : (tmp.D.y < -1e-24 ? (1.0 / tmp.D.y) : BVH_DBL_FAR);
-				tmp.rD.z = tmp.D.z > 1e-24 ? (1.0 / tmp.D.z) : (tmp.D.z < -1e-24 ? (1.0 / tmp.D.z) : BVH_DBL_FAR);
+				tmp.instIdx = instIdx;
+				tmp.hit = ray.hit;
+				tmp.mask = ray.mask;
+				tmp.rD = tinybvh_rcp( tmp.D );
 				// 2. Traverse BLAS with the transformed ray
 				if (blas->IsOccluded( tmp )) return true;
 			}


### PR DESCRIPTION
This commit fixes two related problems.

1. Routines that descend from a TLAS into a BLAS construct a temporary ray but did not consistently fill all fields. For example, ``BVH::IsOccludedTLAS`` did not set the instance index and ray mask. ``BVH::IntersectTLAS`` did not set the mask, and ``BVH_Double::IsOccludedTLAS`` left the hit record uninitialized on top of that. This breaks callbacks that use the mask to select geometry, or the instance index to look up per-instance data. All four routines now forward fields consistently.

2. The double precision ``RayEx`` computed its reciprocal direction with a plain division, which broke handling of axis-parallel rays.The commit introduces ``tinybvh_safercp`` and ``tinybvh_rcp`` overloads and makes the double precision traversal consistent with how the single precision version works.

The commit adds a new test ``tiny_bvh_tlas_state_test.cpp`` that runs float and double traversals into a custom BLAS and checks that the callback sees the right instance index, mask and tmax, for both occlusion and intersection queries.