### PR TITLE
Fix several traversal issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ enable_testing()
 add_executable(tiny_bvh_minimal examples/tiny_bvh_minimal.cpp)
 add_executable(tiny_bvh_renderer examples/tiny_bvh_renderer.cpp)
 add_executable(tiny_bvh_double_test examples/tiny_bvh_double_test.cpp)
+add_executable(tiny_bvh_tlas_state_test examples/tiny_bvh_tlas_state_test.cpp)
 if (NOT EMSCRIPTEN) # EMSCRIPTEN doesn't render anything by default (you would need WebGL/WebGPU)
 	add_executable(tiny_bvh_fenster examples/tiny_bvh_fenster.cpp)
 	target_include_directories(tiny_bvh_fenster PRIVATE ${CMAKE_CURRENT_LIST_DIR})
@@ -47,6 +48,7 @@ endif()
 target_include_directories(tiny_bvh_minimal PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_include_directories(tiny_bvh_renderer PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_include_directories(tiny_bvh_double_test PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(tiny_bvh_tlas_state_test PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 if (NOT MSVC)
 	# Produce debug symbols and set optimization level
@@ -95,6 +97,9 @@ if (NOT MSVC)
 
 	target_compile_options(tiny_bvh_double_test PRIVATE ${common_cxx_flags})
 	target_link_options(tiny_bvh_double_test PRIVATE ${common_link_flags})
+
+	target_compile_options(tiny_bvh_tlas_state_test PRIVATE ${common_cxx_flags})
+	target_link_options(tiny_bvh_tlas_state_test PRIVATE ${common_link_flags})
 
 	# No openmp support in default compiler
 	# set(tiny_bvh_speedtest_cxx_flags ${common_cxx_flags})
@@ -157,3 +162,4 @@ endif()
 
 add_test(NAME "examples/tiny_bvh_minimal" COMMAND tiny_bvh_minimal)
 add_test(NAME "examples/tiny_bvh_double_test" COMMAND tiny_bvh_double_test)
+add_test(NAME "examples/tiny_bvh_tlas_state_test" COMMAND tiny_bvh_tlas_state_test)

--- a/examples/tiny_bvh_anim.cpp
+++ b/examples/tiny_bvh_anim.cpp
@@ -36,7 +36,7 @@ static bvhvec3 eye( -15.24f, 21.5f, 2.54f ), p1, p2, p3;
 static bvhvec3 view = tinybvh_normalize( bvhvec3( 0.826f, -0.438f, -0.356f ) );
 
 // callback for custom geometry: ray/sphere intersection
-bool sphereIntersect( tinybvh::Ray& ray, const unsigned primID )
+bool sphereIntersect( tinybvh::Ray& ray, const unsigned primID, void* )
 {
 	// Note: In TLAS/BLAS traversal, ray.D is not guaranteed to be normalized.
 	float mag = tinybvh_length( ray.D ), reciMag = 1.0f / mag;
@@ -49,7 +49,7 @@ bool sphereIntersect( tinybvh::Ray& ray, const unsigned primID )
 	return hit;
 }
 
-bool sphereIsOccluded( const tinybvh::Ray& ray, const unsigned primID )
+bool sphereIsOccluded( const tinybvh::Ray& ray, const unsigned primID, void* )
 {
 	// Note: In TLAS/BLAS traversal, ray.D is not guaranteed to be normalized.
 	float mag = tinybvh_length( ray.D ), reciMag = 1.0f / mag;
@@ -60,7 +60,8 @@ bool sphereIsOccluded( const tinybvh::Ray& ray, const unsigned primID )
 	return t < ray.hit.t * mag && t > 0;
 }
 
-void sphereAABB( const unsigned primID, bvhvec3& boundsMin, bvhvec3& boundsMax )
+void sphereAABB( const unsigned primID, bvhvec3& boundsMin, bvhvec3& boundsMax,
+	void* )
 {
 	boundsMin = spheres[primID].pos - bvhvec3( spheres[primID].r );
 	boundsMax = spheres[primID].pos + bvhvec3( spheres[primID].r );

--- a/examples/tiny_bvh_anim_double.cpp
+++ b/examples/tiny_bvh_anim_double.cpp
@@ -31,7 +31,7 @@ static bvhvec3 eye( -15.24f, 21.5f, 2.54f ), p1, p2, p3;
 static bvhvec3 view = tinybvh_normalize( bvhvec3( 0.826f, -0.438f, -0.356f ) );
 
 // callback for custom geometry: ray/sphere intersection
-bool sphereIntersect( tinybvh::RayEx& ray, const uint64_t primID )
+bool sphereIntersect( tinybvh::RayEx& ray, const uint64_t primID, void* )
 {
 	// Note: In TLAS/BLAS traversal, ray.D is not guaranteed to be normalized.
 	double mag = tinybvh_length( ray.D ), reciMag = 1.0f / mag;
@@ -44,7 +44,7 @@ bool sphereIntersect( tinybvh::RayEx& ray, const uint64_t primID )
 	return hit;
 }
 
-bool sphereIsOccluded( const tinybvh::RayEx& ray, const uint64_t primID )
+bool sphereIsOccluded( const tinybvh::RayEx& ray, const uint64_t primID, void* )
 {
 	// Note: In TLAS/BLAS traversal, ray.D is not guaranteed to be normalized.
 	double mag = tinybvh_length( ray.D ), reciMag = 1.0f / mag;
@@ -55,7 +55,8 @@ bool sphereIsOccluded( const tinybvh::RayEx& ray, const uint64_t primID )
 	return t < ray.hit.t * mag && t > 0;
 }
 
-void sphereAABB( const uint64_t primID, bvhdbl3& boundsMin, bvhdbl3& boundsMax )
+void sphereAABB( const uint64_t primID, bvhdbl3& boundsMin,
+	bvhdbl3& boundsMax, void* )
 {
 	boundsMin = spheres[primID].pos - bvhdbl3( spheres[primID].r );
 	boundsMax = spheres[primID].pos + bvhdbl3( spheres[primID].r );

--- a/examples/tiny_bvh_collide.cpp
+++ b/examples/tiny_bvh_collide.cpp
@@ -28,7 +28,7 @@ static bvhvec3 eye( -15.24f, 21.5f, 2.54f ), p1, p2, p3;
 static bvhvec3 view = tinybvh_normalize( bvhvec3( 0.826f, -0.438f, -0.356f ) );
 
 // callback for custom geometry: ray/sphere intersection
-bool sphereIntersect( tinybvh::Ray& ray, const unsigned primID )
+bool sphereIntersect( tinybvh::Ray& ray, const unsigned primID, void* )
 {
 	bvhvec3 oc = ray.O - spheres[primID].pos;
 	float b = tinybvh_dot( oc, ray.D ), r = spheres[primID].r;
@@ -40,7 +40,7 @@ bool sphereIntersect( tinybvh::Ray& ray, const unsigned primID )
 	return hit;
 }
 
-bool sphereIsOccluded( const tinybvh::Ray& ray, const unsigned primID )
+bool sphereIsOccluded( const tinybvh::Ray& ray, const unsigned primID, void* )
 {
 	bvhvec3 oc = ray.O - spheres[primID].pos;
 	float b = tinybvh_dot( oc, ray.D ), r = spheres[primID].r;
@@ -50,7 +50,8 @@ bool sphereIsOccluded( const tinybvh::Ray& ray, const unsigned primID )
 	return t < ray.hit.t && t > 0;
 }
 
-void sphereAABB( const unsigned primID, bvhvec3& boundsMin, bvhvec3& boundsMax )
+void sphereAABB( const unsigned primID, bvhvec3& boundsMin, bvhvec3& boundsMax,
+	void* )
 {
 	boundsMin = spheres[primID].pos - bvhvec3( spheres[primID].r );
 	boundsMax = spheres[primID].pos + bvhvec3( spheres[primID].r );

--- a/examples/tiny_bvh_custom.cpp
+++ b/examples/tiny_bvh_custom.cpp
@@ -26,7 +26,7 @@ static bvhvec3 eye( -15.24f, 21.5f, 2.54f ), p1, p2, p3;
 static bvhvec3 view = tinybvh_normalize( bvhvec3( 0.826f, -0.438f, -0.356f ) );
 
 // callback for custom geometry: ray/sphere intersection
-bool sphereIntersect( tinybvh::Ray& ray, const unsigned primID )
+bool sphereIntersect( tinybvh::Ray& ray, const unsigned primID, void* )
 {
 	bvhvec3 oc = ray.O - spheres[primID].pos;
 	float b = tinybvh_dot( oc, ray.D );
@@ -40,7 +40,7 @@ bool sphereIntersect( tinybvh::Ray& ray, const unsigned primID )
 	return hit;
 }
 
-bool sphereIsOccluded( const tinybvh::Ray& ray, const unsigned primID )
+bool sphereIsOccluded( const tinybvh::Ray& ray, const unsigned primID, void* )
 {
 	bvhvec3 oc = ray.O - spheres[primID].pos;
 	float b = tinybvh_dot( oc, ray.D );
@@ -52,7 +52,8 @@ bool sphereIsOccluded( const tinybvh::Ray& ray, const unsigned primID )
 	return t < ray.hit.t && t > 0;
 }
 
-void sphereAABB( const unsigned primID, bvhvec3& boundsMin, bvhvec3& boundsMax )
+void sphereAABB( const unsigned primID, bvhvec3& boundsMin, bvhvec3& boundsMax,
+	void* )
 {
 	boundsMin = spheres[primID].pos - bvhvec3( spheres[primID].r );
 	boundsMax = spheres[primID].pos + bvhvec3( spheres[primID].r );

--- a/examples/tiny_bvh_custom_double.cpp
+++ b/examples/tiny_bvh_custom_double.cpp
@@ -27,7 +27,7 @@ static bvhvec3 eye( -15.24f, 21.5f, 2.54f ), p1, p2, p3;
 static bvhvec3 view = tinybvh_normalize( bvhvec3( 0.826f, -0.438f, -0.356f ) );
 
 // callback for custom geometry: ray/sphere intersection
-bool sphereIntersect( tinybvh::RayEx& ray, const uint64_t primID )
+bool sphereIntersect( tinybvh::RayEx& ray, const uint64_t primID, void* )
 {
 	bvhdbl3 oc = ray.O - spheres[primID].pos;
 	double b = tinybvh_dot( oc, ray.D );
@@ -41,7 +41,7 @@ bool sphereIntersect( tinybvh::RayEx& ray, const uint64_t primID )
 	return hit;
 }
 
-bool sphereIsOccluded( const tinybvh::RayEx& ray, const uint64_t primID )
+bool sphereIsOccluded( const tinybvh::RayEx& ray, const uint64_t primID, void* )
 {
 	bvhdbl3 oc = ray.O - spheres[primID].pos;
 	double b = tinybvh_dot( oc, ray.D );
@@ -53,7 +53,8 @@ bool sphereIsOccluded( const tinybvh::RayEx& ray, const uint64_t primID )
 	return t < ray.hit.t && t > 0;
 }
 
-void sphereAABB( const uint64_t primID, bvhdbl3& boundsMin, bvhdbl3& boundsMax )
+void sphereAABB( const uint64_t primID, bvhdbl3& boundsMin,
+	bvhdbl3& boundsMax, void* )
 {
 	boundsMin = spheres[primID].pos - bvhdbl3( spheres[primID].r );
 	boundsMax = spheres[primID].pos + bvhdbl3( spheres[primID].r );

--- a/examples/tiny_bvh_double_test.cpp
+++ b/examples/tiny_bvh_double_test.cpp
@@ -20,13 +20,13 @@ static int g_failures = 0;
 // ----------------------------------------------------------------------------
 
 struct Sphere { bvhdbl3 pos; double r; };
-static Sphere* g_spheres = 0;
 
-static bool sphereIntersect( RayEx& ray, const uint64_t primID )
+static bool sphereIntersect( RayEx& ray, const uint64_t primID, void* userdata )
 {
-	const bvhdbl3 oc = ray.O - g_spheres[primID].pos;
+	const Sphere* spheres = (const Sphere*)userdata;
+	const bvhdbl3 oc = ray.O - spheres[primID].pos;
 	const double b = tinybvh_dot( oc, ray.D );
-	const double r = g_spheres[primID].r;
+	const double r = spheres[primID].r;
 	const double c = tinybvh_dot( oc, oc ) - r * r;
 	double d = b * b - c;
 	if (d <= 0) return false;
@@ -37,11 +37,13 @@ static bool sphereIntersect( RayEx& ray, const uint64_t primID )
 	return hit;
 }
 
-static bool sphereIsOccluded( const RayEx& ray, const uint64_t primID )
+static bool sphereIsOccluded( const RayEx& ray, const uint64_t primID,
+	void* userdata )
 {
-	const bvhdbl3 oc = ray.O - g_spheres[primID].pos;
+	const Sphere* spheres = (const Sphere*)userdata;
+	const bvhdbl3 oc = ray.O - spheres[primID].pos;
 	const double b = tinybvh_dot( oc, ray.D );
-	const double r = g_spheres[primID].r;
+	const double r = spheres[primID].r;
 	const double c = tinybvh_dot( oc, oc ) - r * r;
 	double d = b * b - c;
 	if (d <= 0) return false;
@@ -50,22 +52,25 @@ static bool sphereIsOccluded( const RayEx& ray, const uint64_t primID )
 	return t < ray.hit.t && t > 0;
 }
 
-static void sphereAABB( const uint64_t primID, bvhdbl3& bmin, bvhdbl3& bmax )
+static void sphereAABB( const uint64_t primID, bvhdbl3& bmin, bvhdbl3& bmax,
+	void* userdata )
 {
-	bmin = g_spheres[primID].pos - bvhdbl3( g_spheres[primID].r );
-	bmax = g_spheres[primID].pos + bvhdbl3( g_spheres[primID].r );
+	const Sphere* spheres = (const Sphere*)userdata;
+	bmin = spheres[primID].pos - bvhdbl3( spheres[primID].r );
+	bmax = spheres[primID].pos + bvhdbl3( spheres[primID].r );
 }
 
 static void TestCustomShadowRays()
 {
 	printf( "Test: double-precision custom-geometry shadow rays...\n" );
 	const int N = 3;
-	g_spheres = new Sphere[N];
-	g_spheres[0].pos = bvhdbl3( 0, 0, 5 ), g_spheres[0].r = 1.0;
-	g_spheres[1].pos = bvhdbl3( 8, 0, 0 ), g_spheres[1].r = 1.0;
-	g_spheres[2].pos = bvhdbl3( 0, -7, 0 ), g_spheres[2].r = 1.0;
+	Sphere spheres[N];
+	spheres[0].pos = bvhdbl3( 0, 0, 5 ), spheres[0].r = 1.0;
+	spheres[1].pos = bvhdbl3( 8, 0, 0 ), spheres[1].r = 1.0;
+	spheres[2].pos = bvhdbl3( 0, -7, 0 ), spheres[2].r = 1.0;
 
 	BVH_Double bvh;
+	bvh.customUserdata = spheres;
 	bvh.Build( &sphereAABB, N );
 	bvh.customIntersect = &sphereIntersect;
 	bvh.customIsOccluded = &sphereIsOccluded;
@@ -96,7 +101,7 @@ static void TestCustomShadowRays()
 	// Occlusion result must agree with Intersect for a batch of directions.
 	for (int i = 0; i < N; i++)
 	{
-		const bvhdbl3 dir = tinybvh_normalize( g_spheres[i].pos );
+		const bvhdbl3 dir = tinybvh_normalize( spheres[i].pos );
 		RayEx shadow( bvhdbl3( 0, 0, 0 ), dir, 1e30 );
 		RayEx probe( bvhdbl3( 0, 0, 0 ), dir, 1e30 );
 		bvh.Intersect( probe );
@@ -104,7 +109,6 @@ static void TestCustomShadowRays()
 		CHECK( bvh.IsOccluded( shadow ) == hit );
 	}
 
-	delete[] g_spheres, g_spheres = 0;
 }
 
 // ----------------------------------------------------------------------------

--- a/examples/tiny_bvh_tlas_state_test.cpp
+++ b/examples/tiny_bvh_tlas_state_test.cpp
@@ -1,0 +1,111 @@
+// Regression tests for state propagation from a TLAS to a custom BLAS.
+//
+// Float and double variants intentionally perform the same setup and checks:
+// a ray with mask 2 skips instance 0, selects instance 1, and must reach the
+// BLAS callback with the selected instance ID, mask, and tmax. Each variant
+// checks both occlusion and intersection traversal; the latter also verifies
+// that the BLAS hit record is returned to the caller.
+
+#define TINYBVH_IMPLEMENTATION
+#define TINYBVH_NO_SIMD
+#include "tiny_bvh.h"
+#include <cstdio>
+
+using namespace tinybvh;
+
+static bool floatStateValid = false, doubleStateValid = false;
+static int floatCalls = 0, doubleCalls = 0;
+
+static void FloatAABB( const unsigned, bvhvec3& bmin, bvhvec3& bmax )
+{
+	bmin = bvhvec3( -1, -1, 4 );
+	bmax = bvhvec3( 1, 1, 6 );
+}
+
+static void DoubleAABB( const uint64_t, bvhdbl3& bmin, bvhdbl3& bmax )
+{
+	bmin = bvhdbl3( -1, -1, 4 );
+	bmax = bvhdbl3( 1, 1, 6 );
+}
+
+static bool FloatOccludes( const Ray& ray, const unsigned )
+{
+	floatCalls++;
+	return floatStateValid = ray.instIdx == (1u << INST_IDX_SHFT) && ray.mask == 2 && ray.hit.t == 3.0f;
+}
+
+static bool DoubleOccludes( const RayEx& ray, const uint64_t )
+{
+	doubleCalls++;
+	return doubleStateValid = ray.instIdx == 1 && ray.mask == 2 && ray.hit.t == 3.0;
+}
+
+static bool FloatIntersects( Ray& ray, const unsigned )
+{
+	floatCalls++;
+	if (!(floatStateValid = ray.instIdx == (1u << INST_IDX_SHFT) && ray.mask == 2 && ray.hit.t == 3.0f)) return false;
+	ray.hit.t = 2.0f;
+	return true;
+}
+
+static bool DoubleIntersects( RayEx& ray, const uint64_t )
+{
+	doubleCalls++;
+	if (!(doubleStateValid = ray.instIdx == 1 && ray.mask == 2 && ray.hit.t == 3.0)) return false;
+	ray.hit.t = 2.0;
+	return true;
+}
+
+static bool TestFloat()
+{
+	BVH blas, tlas;
+	blas.Build( &FloatAABB, 1 );
+	blas.customIsOccluded = &FloatOccludes;
+	blas.customIntersect = &FloatIntersects;
+	BVHBase* blases[] = { &blas };
+	BLASInstance instances[] = { BLASInstance( 0 ), BLASInstance( 0 ) };
+	instances[0].mask = 1;
+	instances[1].mask = 2;
+	tlas.Build( instances, 2, blases, 1 );
+
+	floatCalls = 0;
+	floatStateValid = false;
+	const Ray shadow( bvhvec3( 0, 0, 0 ), bvhvec3( 0, 0, 1 ), 3.0f, 2 );
+	if (!tlas.IsOccluded( shadow ) || floatCalls != 1 || !floatStateValid) return false;
+	floatCalls = 0;
+	floatStateValid = false;
+	Ray probe( bvhvec3( 0, 0, 0 ), bvhvec3( 0, 0, 1 ), 3.0f, 2 );
+	tlas.Intersect( probe );
+	return floatCalls == 1 && floatStateValid && probe.hit.t == 2.0f;
+}
+
+static bool TestDouble()
+{
+	BVH_Double blas, tlas;
+	blas.Build( &DoubleAABB, 1 );
+	blas.customIsOccluded = &DoubleOccludes;
+	blas.customIntersect = &DoubleIntersects;
+	BVH_Double* blases[] = { &blas };
+	BLASInstanceEx instances[] = { BLASInstanceEx( 0 ), BLASInstanceEx( 0 ) };
+	instances[0].mask = 1;
+	instances[1].mask = 2;
+	tlas.Build( instances, 2, blases, 1 );
+
+	doubleCalls = 0;
+	doubleStateValid = false;
+	const RayEx shadow( bvhdbl3( 0, 0, 0 ), bvhdbl3( 0, 0, 1 ), 3.0, 2 );
+	if (!tlas.IsOccluded( shadow ) || doubleCalls != 1 || !doubleStateValid) return false;
+	doubleCalls = 0;
+	doubleStateValid = false;
+	RayEx probe( bvhdbl3( 0, 0, 0 ), bvhdbl3( 0, 0, 1 ), 3.0, 2 );
+	tlas.Intersect( probe );
+	return doubleCalls == 1 && doubleStateValid && probe.hit.t == 2.0;
+}
+
+int main()
+{
+	if (!TestFloat()) { printf( "FAIL: float TLAS state propagation.\n" ); return 1; }
+	if (!TestDouble()) { printf( "FAIL: double TLAS state propagation.\n" ); return 1; }
+	printf( "TLAS state tests passed.\n" );
+	return 0;
+}

--- a/examples/tiny_bvh_tlas_state_test.cpp
+++ b/examples/tiny_bvh_tlas_state_test.cpp
@@ -16,31 +16,31 @@ using namespace tinybvh;
 static bool floatStateValid = false, doubleStateValid = false;
 static int floatCalls = 0, doubleCalls = 0;
 
-static void FloatAABB( const unsigned, bvhvec3& bmin, bvhvec3& bmax )
+static void FloatAABB( const unsigned, bvhvec3& bmin, bvhvec3& bmax, void* )
 {
 	bmin = bvhvec3( -1, -1, 4 );
 	bmax = bvhvec3( 1, 1, 6 );
 }
 
-static void DoubleAABB( const uint64_t, bvhdbl3& bmin, bvhdbl3& bmax )
+static void DoubleAABB( const uint64_t, bvhdbl3& bmin, bvhdbl3& bmax, void* )
 {
 	bmin = bvhdbl3( -1, -1, 4 );
 	bmax = bvhdbl3( 1, 1, 6 );
 }
 
-static bool FloatOccludes( const Ray& ray, const unsigned )
+static bool FloatOccludes( const Ray& ray, const unsigned, void* )
 {
 	floatCalls++;
 	return floatStateValid = ray.instIdx == (1u << INST_IDX_SHFT) && ray.mask == 2 && ray.hit.t == 3.0f;
 }
 
-static bool DoubleOccludes( const RayEx& ray, const uint64_t )
+static bool DoubleOccludes( const RayEx& ray, const uint64_t, void* )
 {
 	doubleCalls++;
 	return doubleStateValid = ray.instIdx == 1 && ray.mask == 2 && ray.hit.t == 3.0;
 }
 
-static bool FloatIntersects( Ray& ray, const unsigned )
+static bool FloatIntersects( Ray& ray, const unsigned, void* )
 {
 	floatCalls++;
 	if (!(floatStateValid = ray.instIdx == (1u << INST_IDX_SHFT) && ray.mask == 2 && ray.hit.t == 3.0f)) return false;
@@ -48,7 +48,7 @@ static bool FloatIntersects( Ray& ray, const unsigned )
 	return true;
 }
 
-static bool DoubleIntersects( RayEx& ray, const uint64_t )
+static bool DoubleIntersects( RayEx& ray, const uint64_t, void* )
 {
 	doubleCalls++;
 	if (!(doubleStateValid = ray.instIdx == 1 && ray.mask == 2 && ray.hit.t == 3.0)) return false;

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -492,34 +492,25 @@ TINYBVH_FORCEINLINE bool tinybvh_isfinite( float f )
 	std::memcpy( &i, &f, sizeof( i ) );
 	return (i & 0x7F800000) != 0x7F800000; // ieee-754: finite if not all exponent bits are 1.
 }
-TINYBVH_FORCEINLINE bool tinybvh_isfinite( double f )
-{
-	uint64_t i;
-	std::memcpy( &i, &f, sizeof( i ) );
-	return (i & 0x7FF0000000000000ull) != 0x7FF0000000000000ull; // ieee-754
-}
 TINYBVH_FORCEINLINE bool tinybvh_isnan( float f )
 {
 	uint32_t i;
 	std::memcpy( &i, &f, sizeof( i ) );
 	return (i & 0x7F800000) == 0x7F800000 && (i & 0x007FFFFF) != 0; // ieee-754
 }
+// Clamp to BVH_FAR rather than FLT_MAX: precomputed products such as
+// ray.O.x * ray.rD.x must not overflow to inf, since inf slab bounds
+// yield NaN or (under FP contraction) -inf and break traversal.
 TINYBVH_FORCEINLINE float tinybvh_safercp( const float x )
 {
-#if 1
-	// my version
-	float r = 1 / x;
-	if (!tinybvh_isfinite( r )) r = copysignf( 3.402823466e+38F /* FLT_MAX */, x );
+	const float r = 1 / x;
+	if (!(fabsf( r ) <= BVH_FAR)) return copysignf( BVH_FAR, x );
 	return r;
-#else
-	// Madmann91's version
-	return fabs( x ) <= FLT_EPSILON ? copysign( 3.402823466e+38F /* FLT_MAX */, x ) : (1.0f / x);
-#endif
 }
 TINYBVH_FORCEINLINE double tinybvh_safercp( const double x )
 {
-	double r = 1 / x;
-	if (!tinybvh_isfinite( r )) r = copysign( 1.7976931348623158e+308 /* DBL_MAX */, x );
+	const double r = 1 / x;
+	if (!(fabs( r ) <= BVH_DBL_FAR)) return copysign( BVH_DBL_FAR, x );
 	return r;
 }
 TINYBVH_FORCEINLINE bvhvec3 tinybvh_safercp( const bvhvec3 a ) { return bvhvec3( tinybvh_safercp( a.x ), tinybvh_safercp( a.y ), tinybvh_safercp( a.z ) ); }

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -4188,6 +4188,7 @@ template <bool posX, bool posY, bool posZ> int32_t BVH::IntersectTLAS( Ray& ray 
 				tmpRay.O = tinybvh_transform_point( ray.O, inst.invTransform );
 				tmpRay.D = tinybvh_transform_vector( ray.D, inst.invTransform );
 				tmpRay.instIdx = instIdx << (32 - INST_IDX_BITS);
+				tmpRay.mask = ray.mask;
 				tmpRay.hit = ray.hit;
 				tmpRay.rD = tinybvh_rcp( tmpRay.D );
 				// 2. Traverse BLAS with the transformed ray
@@ -4327,14 +4328,17 @@ template <bool posX, bool posY, bool posZ> bool BVH::IsOccludedTLAS( const Ray& 
 			for (uint32_t i = 0; i < node->triCount; i++)
 			{
 				// BLAS traversal
-				BLASInstance& inst = instList[primIdx[node->leftFirst + i]];
+				const uint32_t instIdx = primIdx[node->leftFirst + i];
+				BLASInstance& inst = instList[instIdx];
 				const BVHBase* blas = blasList[inst.blasIdx];
 				// Check if the ray should intersect this BLAS Instance, otherwise skip it
 				if (!(inst.mask & ray.mask)) continue;
 				// 1. Transform ray with the inverse of the instance transform
 				tmpRay.O = tinybvh_transform_point( ray.O, inst.invTransform );
 				tmpRay.D = tinybvh_transform_vector( ray.D, inst.invTransform );
-				tmpRay.hit.t = ray.hit.t;
+				tmpRay.instIdx = instIdx << INST_IDX_SHFT;
+				tmpRay.mask = ray.mask;
+				tmpRay.hit = ray.hit;
 				tmpRay.rD = tinybvh_rcp( tmpRay.D );
 				// 2. Traverse BLAS with the transformed ray
 				assert( blas->layout == LAYOUT_BVH || blas->layout == LAYOUT_BVH8_AVX2 || blas->layout == LAYOUT_BVH4_CPU );
@@ -9023,8 +9027,9 @@ int32_t BVH_Double::IntersectTLAS( RayEx& ray ) const
 				tmp.D = tinybvh_transform_vector( ray.D, inst.invTransform );
 				tmp.rD = bvhdbl3( 1.0 / tmp.D.x, 1.0 / tmp.D.y, 1.0 / tmp.D.z );
 				tmp.hit = ray.hit;
-				// 2. Traverse BLAS with the transformed ray
 				tmp.instIdx = instIdx;
+				tmp.mask = ray.mask;
+				// 2. Traverse BLAS with the transformed ray
 				cost += blas->Intersect( tmp );
 				// 3. Restore ray
 				ray.hit = tmp.hit;
@@ -9114,12 +9119,16 @@ bool BVH_Double::IsOccludedTLAS( const RayEx& ray ) const
 			for (uint32_t i = 0; i < node->triCount; i++)
 			{
 				// BLAS traversal
-				BLASInstanceEx& inst = instList[primIdx[node->leftFirst + i]];
+				const uint64_t instIdx = primIdx[node->leftFirst + i];
+				BLASInstanceEx& inst = instList[instIdx];
 				if (!(inst.mask & ray.mask)) continue;
 				BVH_Double* blas = blasList[inst.blasIdx];
 				// 1. Transform ray with the inverse of the instance transform
 				tmp.O = tinybvh_transform_point( ray.O, inst.invTransform );
 				tmp.D = tinybvh_transform_vector( ray.D, inst.invTransform );
+				tmp.instIdx = instIdx;
+				tmp.hit = ray.hit;
+				tmp.mask = ray.mask;
 				tmp.rD.x = tmp.D.x > 1e-24 ? (1.0 / tmp.D.x) : (tmp.D.x < -1e-24 ? (1.0 / tmp.D.x) : BVH_DBL_FAR);
 				tmp.rD.y = tmp.D.y > 1e-24 ? (1.0 / tmp.D.y) : (tmp.D.y < -1e-24 ? (1.0 / tmp.D.y) : BVH_DBL_FAR);
 				tmp.rD.z = tmp.D.z > 1e-24 ? (1.0 / tmp.D.z) : (tmp.D.z < -1e-24 ? (1.0 / tmp.D.z) : BVH_DBL_FAR);

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -1024,7 +1024,7 @@ public:
 	void Build( const bvhvec4* vertices, const uint32_t* indices, const uint32_t primCount );
 	void Build( const bvhvec4slice& vertices, const uint32_t* indices, const uint32_t primCount );
 	void Build( BLASInstance* instances, const uint32_t instCount, BVHBase** blasses, const uint32_t blasCount );
-	void Build( void (*customGetAABB)(const unsigned, bvhvec3&, bvhvec3&), const uint32_t primCount );
+	void Build( void (*customGetAABB)(const unsigned, bvhvec3&, bvhvec3&, void*), const uint32_t primCount );
 	void BuildAABB( const bvhvec4* aabbs, const uint32_t primCount );
 	void BuildHQ( const bvhvec4* vertices, const uint32_t primCount );
 	void BuildHQ( const bvhvec4slice& vertices );
@@ -1113,8 +1113,9 @@ public:
 	uint32_t nextFrag = 0;			// used during SBVH build to keep track of next free fragment.
 	Fragment* fragment = 0;			// input primitive bounding boxes.
 	// Custom geometry intersection callback
-	bool (*customIntersect)(Ray&, const unsigned) = 0;
-	bool (*customIsOccluded)(const Ray&, const unsigned) = 0;
+	bool (*customIntersect)(Ray&, const unsigned, void*) = 0;
+	bool (*customIsOccluded)(const Ray&, const unsigned, void*) = 0;
+	void* customUserdata = 0;
 private:
 #ifdef ENABLE_THREADED_BUILDS
 	// Atomic counters for threaded builds
@@ -1232,7 +1233,7 @@ public:
 	void Build( const bvhdbl3* vertices, const uint64_t primCount );
 	void Build( const bvhdbl3* vertices, const uint32_t* indices, const uint64_t primCount );
 	void Build( BLASInstanceEx* bvhs, const uint64_t instCount, BVH_Double** blasses, const uint64_t blasCount );
-	void Build( void (*customGetAABB)(const uint64_t, bvhdbl3&, bvhdbl3&), const uint64_t primCount );
+	void Build( void (*customGetAABB)(const uint64_t, bvhdbl3&, bvhdbl3&, void*), const uint64_t primCount );
 	void PrepareBuild( const bvhdbl3* vertices, const uint32_t* indices, const uint64_t primCount );
 	void Build( uint64_t nodeIdx = 0, uint32_t depth = 0 );
 	double SAHCost( const uint64_t nodeIdx = 0 ) const;
@@ -1258,8 +1259,9 @@ public:
 	bvhdbl3 aabbMin, aabbMax;		// bounds of the root node of the BVH.
 	bool threadedBuild = true;		// will be disabled for small meshes.
 	// Custom geometry intersection callback
-	bool (*customIntersect)(RayEx&, uint64_t) = 0;
-	bool (*customIsOccluded)(const RayEx&, uint64_t) = 0;
+	bool (*customIntersect)(RayEx&, uint64_t, void*) = 0;
+	bool (*customIsOccluded)(const RayEx&, uint64_t, void*) = 0;
+	void* customUserdata = 0;
 #ifdef ENABLE_THREADED_BUILDS
 private:
 	// Atomic counter for threaded builds
@@ -2222,7 +2224,7 @@ void BVH::BuildAABB( const bvhvec4* aabbs, const uint32_t aabbCount )
 	Build();
 }
 
-void BVH::Build( void (*customGetAABB)(const unsigned, bvhvec3&, bvhvec3&), const uint32_t primCount )
+void BVH::Build( void (*customGetAABB)(const unsigned, bvhvec3&, bvhvec3&, void*), const uint32_t primCount )
 {
 	// BVH builder for custom geometry; AABBs are obtained via a function pointer in context.
 	BVH_FATAL_ERROR_IF( primCount == 0, "BVH::Build( void (*customGetAABB)( .. ), instCount ), instCount == 0." );
@@ -2244,7 +2246,7 @@ void BVH::Build( void (*customGetAABB)(const unsigned, bvhvec3&, bvhvec3&), cons
 	root.leftFirst = 0, root.triCount = primCount, root.aabbMin = bvhvec3( BVH_FAR ), root.aabbMax = bvhvec3( -BVH_FAR );
 	for (uint32_t i = 0; i < primCount; i++)
 	{
-		customGetAABB( i, fragment[i].bmin, fragment[i].bmax );
+		customGetAABB( i, fragment[i].bmin, fragment[i].bmax, customUserdata );
 		fragment[i].primIdx = i, fragment[i].clipped = 0, primIdx[i] = i;
 		root.aabbMin = tinybvh_min( root.aabbMin, fragment[i].bmin );
 		root.aabbMax = tinybvh_max( root.aabbMax, fragment[i].bmax );
@@ -4133,7 +4135,7 @@ template <bool posX, bool posY, bool posZ> int32_t BVH::Intersect( Ray& ray ) co
 			}
 			else if (customEnabled && customIntersect != 0) for (uint32_t i = 0; i < node->triCount; i++, cost += c_int)
 			{
-				if ((*customIntersect)(ray, primIdx[node->leftFirst + i]))
+				if ((*customIntersect)(ray, primIdx[node->leftFirst + i], customUserdata))
 				{
 				#if INST_IDX_BITS == 32
 					ray.hit.inst = ray.instIdx;
@@ -4290,7 +4292,7 @@ template <bool posX, bool posY, bool posZ> bool BVH::IsOccluded( const Ray& ray 
 			else if (customEnabled && customIsOccluded != 0)
 			{
 				for (uint32_t i = 0; i < node->triCount; i++)
-					if ((*customIsOccluded)(ray, primIdx[node->leftFirst + i])) return true;
+					if ((*customIsOccluded)(ray, primIdx[node->leftFirst + i], customUserdata)) return true;
 			}
 			else for (uint32_t i = 0; i < node->triCount; i++)
 			{
@@ -8655,7 +8657,7 @@ BVH_Double::~BVH_Double()
 	AlignedFree( primIdx );
 }
 
-void BVH_Double::Build( void (*customGetAABB)(const uint64_t, bvhdbl3&, bvhdbl3&), const uint64_t primCount )
+void BVH_Double::Build( void (*customGetAABB)(const uint64_t, bvhdbl3&, bvhdbl3&, void*), const uint64_t primCount )
 {
 	BVH_FATAL_ERROR_IF( primCount == 0, "BVH_Double::Build( void (*customGetAABB)( .. ), instCount ), instCount == 0." );
 	triCount = idxCount = primCount;
@@ -8675,7 +8677,7 @@ void BVH_Double::Build( void (*customGetAABB)(const uint64_t, bvhdbl3&, bvhdbl3&
 	root.leftFirst = 0, root.triCount = primCount, root.aabbMin = bvhvec3( BVH_FAR ), root.aabbMax = bvhvec3( -BVH_FAR );
 	for (uint32_t i = 0; i < primCount; i++)
 	{
-		customGetAABB( i, fragment[i].bmin, fragment[i].bmax );
+		customGetAABB( i, fragment[i].bmin, fragment[i].bmax, customUserdata );
 		root.aabbMin = tinybvh_min( root.aabbMin, fragment[i].bmin ), fragment[i].primIdx = i;
 		root.aabbMax = tinybvh_max( root.aabbMax, fragment[i].bmax ), primIdx[i] = i;
 	}
@@ -8960,7 +8962,7 @@ int32_t BVH_Double::Intersect( RayEx& ray ) const
 			if (customEnabled && customIntersect != 0)
 			{
 				for (uint32_t i = 0; i < node->triCount; i++, cost += c_int)
-					if ((*customIntersect)(ray, primIdx[node->leftFirst + i]))
+					if ((*customIntersect)(ray, primIdx[node->leftFirst + i], customUserdata))
 						ray.hit.inst = ray.instIdx;
 			}
 			else for (uint32_t i = 0; i < node->triCount; i++, cost += c_int)
@@ -9071,7 +9073,7 @@ bool BVH_Double::IsOccluded( const RayEx& ray ) const
 			if (customEnabled && customIsOccluded != 0)
 			{
 				for (uint32_t i = 0; i < node->triCount; i++)
-					if ((*customIsOccluded)(ray, primIdx[node->leftFirst + i])) return true;
+					if ((*customIsOccluded)(ray, primIdx[node->leftFirst + i], customUserdata)) return true;
 			}
 			else for (uint32_t i = 0; i < node->triCount; i++)
 			{

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -653,6 +653,16 @@ constexpr bvhdbl3 operator*=( bvhdbl3& a, const double b ) { return bvhdbl3( a.x
 
 #endif // TINYBVH_USE_CUSTOM_VECTOR_TYPES
 
+struct bvhdbl3slice
+{
+	bvhdbl3slice() = default;
+	bvhdbl3slice( const bvhdbl3* data, uint64_t count, uint64_t stride = sizeof( bvhdbl3 ) );
+	constexpr operator bool() const { return !!data; }
+	const bvhdbl3& operator [] ( size_t i ) const;
+	const int8_t* data = nullptr;
+	uint64_t count, stride;
+};
+
 TINYBVH_FORCEINLINE double tinybvh_length( const bvhdbl3& a ) { return sqrt( a.x * a.x + a.y * a.y + a.z * a.z ); }
 TINYBVH_FORCEINLINE bvhdbl3 tinybvh_normalize( const bvhdbl3& a )
 {
@@ -1231,10 +1241,12 @@ public:
 	BVH_Double& operator=( const BVH_Double& ) = default;
 	~BVH_Double();
 	void Build( const bvhdbl3* vertices, const uint64_t primCount );
+	void Build( const bvhdbl3slice& vertices );
 	void Build( const bvhdbl3* vertices, const uint32_t* indices, const uint64_t primCount );
+	void Build( const bvhdbl3slice& vertices, const uint32_t* indices, const uint64_t primCount );
 	void Build( BLASInstanceEx* bvhs, const uint64_t instCount, BVH_Double** blasses, const uint64_t blasCount );
 	void Build( void (*customGetAABB)(const uint64_t, bvhdbl3&, bvhdbl3&, void*), const uint64_t primCount );
-	void PrepareBuild( const bvhdbl3* vertices, const uint32_t* indices, const uint64_t primCount );
+	void PrepareBuild( const bvhdbl3slice& vertices, const uint32_t* indices, const uint64_t primCount );
 	void Build( uint64_t nodeIdx = 0, uint32_t depth = 0 );
 	double SAHCost( const uint64_t nodeIdx = 0 ) const;
 	int32_t Intersect( RayEx& ray ) const;
@@ -1242,7 +1254,7 @@ public:
 	bool IsOccludedTLAS( const RayEx& ray ) const;
 	int32_t IntersectTLAS( RayEx& ray ) const;
 	bool isIndexed() const { return vertIdx != 0; }
-	bvhdbl3* verts = 0;				// pointer to input primitive array, double-precision, 3x24 bytes per tri.
+	bvhdbl3slice verts = {};		// pointer to input primitive array, double-precision, 3x24 bytes per tri.
 	uint32_t* vertIdx = 0;			// vertex indices, only used in case the BVH is built over indexed prims.
 	Fragment* fragment = 0;			// input primitive bounding boxes, double-precision.
 	BVHNode* bvhNode = 0;			// BVH node, double precision format.
@@ -1842,6 +1854,23 @@ const bvhvec4& bvhvec4slice::operator[]( size_t i ) const
 #endif
 	return *reinterpret_cast<const bvhvec4*>(data + stride * i);
 }
+
+#ifdef DOUBLE_PRECISION_SUPPORT
+
+bvhdbl3slice::bvhdbl3slice( const bvhdbl3* data, uint64_t count, uint64_t stride ) :
+	data{ reinterpret_cast<const int8_t*>(data) },
+	count{ count }, stride{ stride } {
+}
+
+const bvhdbl3& bvhdbl3slice::operator[]( size_t i ) const
+{
+#ifdef PARANOID
+	BVH_FATAL_ERROR_IF( i >= count, "bvhdbl3slice::[..], Reading outside slice." );
+#endif
+	return *reinterpret_cast<const bvhdbl3*>(data + stride * i);
+}
+
+#endif // DOUBLE_PRECISION_SUPPORT
 
 // LBVH builder helpers
 // ----------------------------------------------------------------------------
@@ -8724,19 +8753,19 @@ void BVH_Double::Build( BLASInstanceEx* bvhs, const uint64_t instCount, BVH_Doub
 	Build();
 }
 
-void BVH_Double::Build( const bvhdbl3* vertices, const uint64_t primCount )
-{
-	Build( vertices, 0, primCount );
-}
+void BVH_Double::Build( const bvhdbl3slice& v ) { Build( v, 0, 0 ); }
+void BVH_Double::Build( const bvhdbl3* v, const uint64_t p ) { Build( bvhdbl3slice{ v, p * 3, sizeof( bvhdbl3 ) }, 0, p ); }
+void BVH_Double::Build( const bvhdbl3* v, const uint32_t* i, const uint64_t p ) { Build( bvhdbl3slice{ v, p * 3, sizeof( bvhdbl3 ) }, i, p ); }
 
-void BVH_Double::Build( const bvhdbl3* vertices, const uint32_t* indices, const uint64_t primCount )
+void BVH_Double::Build( const bvhdbl3slice& vertices, const uint32_t* indices, const uint64_t primCount )
 {
 	PrepareBuild( vertices, indices, primCount );
 	Build();
 }
 
-void BVH_Double::PrepareBuild( const bvhdbl3* vertices, const uint32_t* indices, const uint64_t primCount )
+void BVH_Double::PrepareBuild( const bvhdbl3slice& vertices, const uint32_t* indices, const uint64_t prims )
 {
+	const uint64_t primCount = prims > 0 ? prims : vertices.count / 3;
 	BVH_FATAL_ERROR_IF( primCount == 0, "BVH_Double::PrepareBuild( .. ), primCount == 0." );
 	const uint64_t spaceNeeded = primCount * 2; // upper limit
 	// allocate memory on first build
@@ -8750,7 +8779,7 @@ void BVH_Double::PrepareBuild( const bvhdbl3* vertices, const uint32_t* indices,
 		primIdx = (uint64_t*)AlignedAlloc( primCount * sizeof( uint64_t ) );
 		fragment = (Fragment*)AlignedAlloc( primCount * sizeof( Fragment ) );
 	}
-	verts = (bvhdbl3*)vertices; // note: we're not copying this data; don't delete.
+	verts = vertices; // note: we're not copying this data; don't delete.
 	vertIdx = (uint32_t*)indices; // also not copied; for indexed triangle meshes.
 	idxCount = triCount = primCount;
 	// prepare fragments

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -4066,18 +4066,18 @@ bool BVH::IntersectSphere( const bvhvec3& pos, const float r ) const
 }
 
 #define SLAB_TEST_TWO_NODES \
-	float tx1a = (posX ? child1->aabbMin.x : child1->aabbMax.x) * ray.rD.x - rox; /* expect fma. */ \
-	float ty1a = (posY ? child1->aabbMin.y : child1->aabbMax.y) * ray.rD.y - roy; \
-	float tz1a = (posZ ? child1->aabbMin.z : child1->aabbMax.z) * ray.rD.z - roz; \
-	float tx1b = (posX ? child2->aabbMin.x : child2->aabbMax.x) * ray.rD.x - rox; \
-	float ty1b = (posY ? child2->aabbMin.y : child2->aabbMax.y) * ray.rD.y - roy; \
-	float tz1b = (posZ ? child2->aabbMin.z : child2->aabbMax.z) * ray.rD.z - roz; \
-	float tx2a = (posX ? child1->aabbMax.x : child1->aabbMin.x) * ray.rD.x - rox; \
-	float ty2a = (posY ? child1->aabbMax.y : child1->aabbMin.y) * ray.rD.y - roy; \
-	float tz2a = (posZ ? child1->aabbMax.z : child1->aabbMin.z) * ray.rD.z - roz; \
-	float tx2b = (posX ? child2->aabbMax.x : child2->aabbMin.x) * ray.rD.x - rox; \
-	float ty2b = (posY ? child2->aabbMax.y : child2->aabbMin.y) * ray.rD.y - roy; \
-	float tz2b = (posZ ? child2->aabbMax.z : child2->aabbMin.z) * ray.rD.z - roz; \
+	float tx1a = tinybvh_fma( posX ? child1->aabbMin.x : child1->aabbMax.x, ray.rD.x, -rox ); \
+	float ty1a = tinybvh_fma( posY ? child1->aabbMin.y : child1->aabbMax.y, ray.rD.y, -roy ); \
+	float tz1a = tinybvh_fma( posZ ? child1->aabbMin.z : child1->aabbMax.z, ray.rD.z, -roz ); \
+	float tx1b = tinybvh_fma( posX ? child2->aabbMin.x : child2->aabbMax.x, ray.rD.x, -rox ); \
+	float ty1b = tinybvh_fma( posY ? child2->aabbMin.y : child2->aabbMax.y, ray.rD.y, -roy ); \
+	float tz1b = tinybvh_fma( posZ ? child2->aabbMin.z : child2->aabbMax.z, ray.rD.z, -roz ); \
+	float tx2a = tinybvh_fma( posX ? child1->aabbMax.x : child1->aabbMin.x, ray.rD.x, -rox ); \
+	float ty2a = tinybvh_fma( posY ? child1->aabbMax.y : child1->aabbMin.y, ray.rD.y, -roy ); \
+	float tz2a = tinybvh_fma( posZ ? child1->aabbMax.z : child1->aabbMin.z, ray.rD.z, -roz ); \
+	float tx2b = tinybvh_fma( posX ? child2->aabbMax.x : child2->aabbMin.x, ray.rD.x, -rox ); \
+	float ty2b = tinybvh_fma( posY ? child2->aabbMax.y : child2->aabbMin.y, ray.rD.y, -roy ); \
+	float tz2b = tinybvh_fma( posZ ? child2->aabbMax.z : child2->aabbMin.z, ray.rD.z, -roz ); \
 	float tmina = tinybvh_max( tinybvh_max( tx1a, ty1a ), tinybvh_max( tz1a, 0.0f ) ); \
 	float tminb = tinybvh_max( tinybvh_max( tx1b, ty1b ), tinybvh_max( tz1b, 0.0f ) ); \
 	float tmaxa = tinybvh_min( tinybvh_min( tx2a, ty2a ), tinybvh_min( tz2a, ray.hit.t ) ); \

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -492,6 +492,12 @@ TINYBVH_FORCEINLINE bool tinybvh_isfinite( float f )
 	std::memcpy( &i, &f, sizeof( i ) );
 	return (i & 0x7F800000) != 0x7F800000; // ieee-754: finite if not all exponent bits are 1.
 }
+TINYBVH_FORCEINLINE bool tinybvh_isfinite( double f )
+{
+	uint64_t i;
+	std::memcpy( &i, &f, sizeof( i ) );
+	return (i & 0x7FF0000000000000ull) != 0x7FF0000000000000ull; // ieee-754
+}
 TINYBVH_FORCEINLINE bool tinybvh_isnan( float f )
 {
 	uint32_t i;
@@ -509,6 +515,12 @@ TINYBVH_FORCEINLINE float tinybvh_safercp( const float x )
 	// Madmann91's version
 	return fabs( x ) <= FLT_EPSILON ? copysign( 3.402823466e+38F /* FLT_MAX */, x ) : (1.0f / x);
 #endif
+}
+TINYBVH_FORCEINLINE double tinybvh_safercp( const double x )
+{
+	double r = 1 / x;
+	if (!tinybvh_isfinite( r )) r = copysign( 1.7976931348623158e+308 /* DBL_MAX */, x );
+	return r;
 }
 TINYBVH_FORCEINLINE bvhvec3 tinybvh_safercp( const bvhvec3 a ) { return bvhvec3( tinybvh_safercp( a.x ), tinybvh_safercp( a.y ), tinybvh_safercp( a.z ) ); }
 TINYBVH_FORCEINLINE bvhvec3 tinybvh_rcp( const bvhvec3 a ) { return tinybvh_safercp( a ); /* bvhvec3( 1.0f / a.x, 1.0f / a.y, 1.0f / a.z ); */ }
@@ -656,6 +668,8 @@ TINYBVH_FORCEINLINE bvhdbl3 tinybvh_normalize( const bvhdbl3& a )
 	double l = tinybvh_length( a ), rl = l == 0 ? 0 : (1.0 / l);
 	return a * rl;
 }
+TINYBVH_FORCEINLINE bvhdbl3 tinybvh_safercp( const bvhdbl3 a ) { return bvhdbl3( tinybvh_safercp( a.x ), tinybvh_safercp( a.y ), tinybvh_safercp( a.z ) ); }
+TINYBVH_FORCEINLINE bvhdbl3 tinybvh_rcp( const bvhdbl3 a ) { return tinybvh_safercp( a ); }
 inline bvhdbl3 tinybvh_transform_point( const bvhdbl3& v, const double* T )
 {
 	const bvhdbl3 res(
@@ -824,7 +838,7 @@ struct RayEx
 		O = origin, D = direction;
 		double rl = 1.0 / sqrt( D.x * D.x + D.y * D.y + D.z * D.z );
 		D.x *= rl, D.y *= rl, D.z *= rl;
-		rD.x = 1.0 / D.x, rD.y = 1.0 / D.y, rD.z = 1.0 / D.z;
+		rD = tinybvh_rcp( D );
 		hit.u = hit.v = 0, hit.t = tmax;
 		instIdx = 0;
 		mask = rayMask & RAY_MASK_INTERSECT_ALL;
@@ -9025,10 +9039,10 @@ int32_t BVH_Double::IntersectTLAS( RayEx& ray ) const
 				// 1. Transform ray with the inverse of the instance transform
 				tmp.O = tinybvh_transform_point( ray.O, inst.invTransform );
 				tmp.D = tinybvh_transform_vector( ray.D, inst.invTransform );
-				tmp.rD = bvhdbl3( 1.0 / tmp.D.x, 1.0 / tmp.D.y, 1.0 / tmp.D.z );
 				tmp.hit = ray.hit;
 				tmp.instIdx = instIdx;
 				tmp.mask = ray.mask;
+				tmp.rD = tinybvh_rcp( tmp.D );
 				// 2. Traverse BLAS with the transformed ray
 				cost += blas->Intersect( tmp );
 				// 3. Restore ray
@@ -9129,9 +9143,7 @@ bool BVH_Double::IsOccludedTLAS( const RayEx& ray ) const
 				tmp.instIdx = instIdx;
 				tmp.hit = ray.hit;
 				tmp.mask = ray.mask;
-				tmp.rD.x = tmp.D.x > 1e-24 ? (1.0 / tmp.D.x) : (tmp.D.x < -1e-24 ? (1.0 / tmp.D.x) : BVH_DBL_FAR);
-				tmp.rD.y = tmp.D.y > 1e-24 ? (1.0 / tmp.D.y) : (tmp.D.y < -1e-24 ? (1.0 / tmp.D.y) : BVH_DBL_FAR);
-				tmp.rD.z = tmp.D.z > 1e-24 ? (1.0 / tmp.D.z) : (tmp.D.z < -1e-24 ? (1.0 / tmp.D.z) : BVH_DBL_FAR);
+				tmp.rD = tinybvh_rcp( tmp.D );
 				// 2. Traverse BLAS with the transformed ray
 				if (blas->IsOccluded( tmp )) return true;
 			}


### PR DESCRIPTION
This PR fixes four separate issues I stumbled into while playing with an experimental Mitsuba version that uses TinyBVH for ray tracing. Below is a summary of each change:

### Commit 1: Forward the complete ray state from a TLAS to its BLAS instances

Routines that descend from a TLAS into a BLAS construct a temporary ray but did not consistently fill all fields. For example, `BVH::IsOccludedTLAS` did not set the instance index and ray mask. `BVH::IntersectTLAS` did not set the mask, and `BVH_Double::IsOccludedTLAS` left the hit record uninitialized on top of that. This breaks callbacks that use the mask to select geometry, or the instance index to look up per-instance data. All four routines now forward `instIdx`, `mask` and the full `hit` record.

This commit also adds a new test `tiny_bvh_tlas_state_test.cpp` that runs float and double traversals into a custom BLAS and checks that the callback sees the right instance index, mask and tmax, for both occlusion and intersection queries.

### Commit 2: Compute single/double precision ray reciprocals the same way

Reciprocal ray directions are not computed consistently. `Ray` builds its reciprocal with `rD = tinybvh_rcp( D )`, which guards against zero directions. The double precision version `RayEx` skips this and directly writes `rD.x = 1.0 / D.x`, which means that an axis-parallel ray ends up with an infinity in one component. This commit adds double precision overloads of `tinybvh_safercp` and `tinybvh_rcp`, and then makes the `RayEx` class consistent with `Ray`.

### Commit 3: Clamp safe ray reciprocals to BVH_FAR

This commit revisits `tinybvh_safercp` changed in the previous commit to address another issue. The current implementation (e.g., on single precision) clamps to `FLT_MAX`, which keeps the reciprocal finite but not the values the traversal derives from it. The traversal computes

```cpp
const float rox = ray.O.x * ray.rD.x;
...
float tx1a = (posX ? child1->aabbMin.x : child1->aabbMax.x) * ray.rD.x - rox; /* expect fma. */
```

For a ray with `D.x == 0` and therefore `rD.x == FLT_MAX`, both products overflow once the coordinates involved exceed 1. The subtraction then gives `NaN` on every node the ray tests and the ray misses the scene entirely.

This commit changes both `tinybvh_safercp()` overloads to clamp to `BVH_FAR` and `BVH_DBL_FAR`, which sit far enough below the representable maximum for those products to stay finite.

### Commit 4: Add userdata to custom-geometry callbacks

Custom-geometry callbacks receive only a ray and a primitive ID. That is insufficient for applications that use one static callback for multiple BVHs because the callback needs to know from where to load data associated with the ID.

This commit adds a per-BVH `customUserdata` pointer it to the custom AABB, intersection, and occlusion callbacks in BVH and BVH_Double. It also adapts the example code.