### PR TITLE
PreSplitting: Reduce time with fast `cbrtf` approximation

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -3841,12 +3841,24 @@ void BVH::SplitLeafs( const uint32_t maxPrims )
 
 float BVH::SplitPriority( const Fragment& f ) const
 {
+	auto fastCbrt = [](float x) {
+		// x >= 0.0f is assumed
+		uint32_t i = *(uint32_t*)&x;
+		i = 0x2A51067Fu + i / 3u;
+		float y = *(float*)&i;
+		
+		// Refine with Newton-Raphson iterations
+		y = (2.0f * y + x / (y * y)) * (1.0f / 3.0f);
+
+		return y;
+	};
+
 	const bvhvec3 extent = f.bmax - f.bmin;
 	const float extentPrio = tinybvh_sqrf( extent[tinybvh_maxdim( extent )] );
 	const float boxArea = 2 * tinybvh_halfarea( extent ); // TODO: half of this seems more appropriate?
 	const float triArea = PrimArea( f.primIdx );
 	const float emptyAreaPrio = boxArea - triArea;
-	return cbrtf( extentPrio * emptyAreaPrio );
+	return fastCbrt( extentPrio * emptyAreaPrio );
 }
 
 int BVH::SplitCount( const float prio, const float sumPrio, const int tris, const float factor ) const


### PR DESCRIPTION
I was looking into improving PreSplitting time and somewhat suprisingly the `cbrtf` call takes most of the time.
AI gave me this fast approximation: https://godbolt.org/z/arP9GdGxd

Results on Sponza (N=262267), PreSplitting time:
```
Reference: 14.91ms, Splits=45'126
fastCbrtf: 7.465ms, Splits=45'128
```
Time is halved! As you can see there is a minor difference in splits from the approximation. To fix that we could just add an other Newton-Raphson iteration, but I don't think its worth it.

Since I'm interested in SweepSAH+PreSplit:
```
Before:
BVH BUILD - 2-wide BVH (full-sweep + presplit) - Crytek Sponza (262k tris)
build time: 55.72ms SAH: 71.984, EPO: 21.70

After:
BVH BUILD - 2-wide BVH (full-sweep + presplit) - Crytek Sponza (262k tris)
build time: 47.23ms SAH: 71.992, EPO: 21.71
```

---
One could also look into an alternative `Priority(triangle)` formulation that doesn't involve `cbrtf` at all.