### PR TITLE
Drop the absolute determinant epsilon from the triangle tests

### DIFF
--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -1852,16 +1852,15 @@ bool BVH_SoA::IsOccluded( const Ray& ) const { BVH_FATAL_ERROR( "BVH_SoA::IsOccl
 #define MOLLER_TRUMBORE_TEST( tmax, exit ) \
 	const bvhvec3 h = tinybvh_cross( ray.D, e2 );	\
 	const float a = tinybvh_dot( e1, h );			\
-	if (fabs( a ) < 0.000001f) exit;				\
+	if (a == 0) exit;								\
 	const float f = 1 / a;							\
 	const bvhvec3 s = ray.O - v0;					\
 	const float u = f * tinybvh_dot( s, h );		\
 	const bvhvec3 q = tinybvh_cross( s, e1 );		\
 	const float v = f * tinybvh_dot( ray.D, q );	\
-	const bool miss = u < 0 || v < 0 || u + v > 1;	\
-	if (miss) exit;									\
+	if (!(u >= 0 && v >= 0 && u + v <= 1)) exit;	\
 	const float t = f * tinybvh_dot( e2, q );		\
-	if (t < 0 || t > tmax) exit;
+	if (!(t >= 0 && t <= tmax)) exit;
 
 // code compaction: fetching triangle vertices, with or without indices.
 #define GET_PRIM_INDICES_I0_I1_I2( bvh, idx ) if (indexedEnabled && bvh.vertIdx != 0) \
@@ -4149,13 +4148,13 @@ void BVH::Intersect256Rays( Ray* packet ) const
 					Ray& ray = packet[i];
 					const bvhvec3 h = tinybvh_cross( ray.D, e2 );
 					const float a = tinybvh_dot( e1, h );
-					if (fabs( a ) < 0.0000001f) continue; // ray parallel to triangle
+					if (a == 0) continue; // ray parallel to triangle
 					const float f = 1 / a, u = f * tinybvh_dot( s, h );
 					const bvhvec3 q = tinybvh_cross( s, e1 );
 					const float v = f * tinybvh_dot( ray.D, q );
-					if (u < 0 || v < 0 || u + v > 1) continue;
+					if (!(u >= 0 && v >= 0 && u + v <= 1)) continue;
 					const float t = f * tinybvh_dot( e2, q );
-					if (t <= 0 || t >= ray.hit.t) continue;
+					if (!(t > 0 && t < ray.hit.t)) continue;
 					ray.hit.t = t, ray.hit.u = u, ray.hit.v = v;
 				#if INST_IDX_BITS == 32
 					ray.hit.prim = idx, ray.hit.inst = ray.instIdx;
@@ -7494,13 +7493,13 @@ void BVH::Intersect256RaysSSE( Ray* packet ) const
 					Ray& ray = packet[i];
 					const bvhvec3 h = tinybvh_cross( ray.D, e2 );
 					const float a = tinybvh_dot( e1, h );
-					if (fabs( a ) < 0.0000001f) continue; // ray parallel to triangle
+					if (a == 0) continue; // ray parallel to triangle
 					const float f = 1 / a, u = f * tinybvh_dot( s, h );
 					const bvhvec3 q = tinybvh_cross( s, e1 );
 					const float v = f * tinybvh_dot( ray.D, q );
-					if (u < 0 || v < 0 || u + v > 1) continue;
+					if (!(u >= 0 && v >= 0 && u + v <= 1)) continue;
 					const float t = f * tinybvh_dot( e2, q );
-					if (t <= 0 || t >= ray.hit.t) continue;
+					if (!(t > 0 && t < ray.hit.t)) continue;
 					ray.hit.t = t, ray.hit.u = u, ray.hit.v = v, ray.hit.prim = idx;
 				}
 			}
@@ -9241,13 +9240,13 @@ int32_t BVH_Double::Intersect( RayEx& ray ) const
 				const bvhdbl3 e2 = verts[i2] - verts[i0];
 				const bvhdbl3 h = tinybvh_cross( ray.D, e2 );
 				const double a = tinybvh_dot( e1, h );
-				if (fabs( a ) < 0.0000001) continue; // ray parallel to triangle
+				if (a == 0) continue; // ray parallel to triangle
 				const double f = 1 / a;
 				const bvhdbl3 s = ray.O - verts[i0];
 				const double u = f * tinybvh_dot( s, h );
 				const bvhdbl3 q = tinybvh_cross( s, e1 );
 				const double v = f * tinybvh_dot( ray.D, q );
-				if (u < 0 || v < 0 || u + v > 1) continue;
+				if (!(u >= 0 && v >= 0 && u + v <= 1)) continue;
 				const double t = f * tinybvh_dot( e2, q );
 				if (t > 0 && t < ray.hit.t)
 				{
@@ -9351,13 +9350,13 @@ bool BVH_Double::IsOccluded( const RayEx& ray ) const
 				const bvhdbl3 e2 = verts[i2] - verts[i0];
 				const bvhdbl3 h = tinybvh_cross( ray.D, e2 );
 				const double a = tinybvh_dot( e1, h );
-				if (fabs( a ) < 0.0000001) continue; // ray parallel to triangle
+				if (a == 0) continue; // ray parallel to triangle
 				const double f = 1 / a;
 				const bvhdbl3 s = ray.O - verts[i0];
 				const double u = f * tinybvh_dot( s, h );
 				const bvhdbl3 q = tinybvh_cross( s, e1 );
 				const double v = f * tinybvh_dot( ray.D, q );
-				if (u < 0 || v < 0 || u + v > 1) continue;
+				if (!(u >= 0 && v >= 0 && u + v <= 1)) continue;
 				const double t = f * tinybvh_dot( e2, q );
 				if (t > 0 && t < ray.hit.t) return true;
 			}
@@ -9565,13 +9564,13 @@ void BVHBase::IntersectTri( Ray& ray, const uint32_t triIdx, const bvhvec4slice&
 	const float Bx = B[kx] - Sx * B[kz], By = B[ky] - Sy * B[kz];
 	const float Cx = C[kx] - Sx * C[kz], Cy = C[ky] - Sy * C[kz];
 	const float U = Cx * By - Cy * Bx, V = Ax * Cy - Ay * Cx, W = Bx * Ay - By * Ax;
-	if ((U < 0 || V < 0 || W < 0) && (U > 0 || V > 0 || W > 0)) return;
+	if (!((U >= 0 && V >= 0 && W >= 0) || (U <= 0 && V <= 0 && W <= 0))) return;
 	const float det = U + V + W;
 	if (det == 0) return;
 	const float Az = Sz * A[kz], Bz = Sz * B[kz], Cz = Sz * C[kz];
 	const float T = U * Az + V * Bz + W * Cz;
 	const float invDet = 1.0f / det, t = T * invDet;
-	if (t >= ray.hit.t || t < 0) return;
+	if (!(t >= 0 && t < ray.hit.t)) return;
 	const float u = U * invDet, v = V * invDet;
 #else
 	// Moeller-Trumbore ray/triangle intersection algorithm.
@@ -9614,13 +9613,13 @@ bool BVHBase::TriOccludes( const Ray& ray, const bvhvec4slice& verts, const uint
 	const float Bx = B[kx] - Sx * B[kz], By = B[ky] - Sy * B[kz];
 	const float Cx = C[kx] - Sx * C[kz], Cy = C[ky] - Sy * C[kz];
 	const float U = Cx * By - Cy * Bx, V = Ax * Cy - Ay * Cx, W = Bx * Ay - By * Ax;
-	if ((U < 0 || V < 0 || W < 0) && (U > 0 || V > 0 || W > 0)) return false;
+	if (!((U >= 0 && V >= 0 && W >= 0) || (U <= 0 && V <= 0 && W <= 0))) return false;
 	const float det = U + V + W;
 	if (det == 0) return false;
 	const float Az = Sz * A[kz], Bz = Sz * B[kz], Cz = Sz * C[kz];
 	const float T = U * Az + V * Bz + W * Cz;
 	const float invDet = 1.0f / det, t = T * invDet;
-	if (t < 0 || t > ray.hit.t) return false;
+	if (!(t >= 0 && t <= ray.hit.t)) return false;
 	const float u = U * invDet, v = V * invDet;
 #else
 	// Moeller-Trumbore ray/triangle intersection algorithm


### PR DESCRIPTION
Several implementations of the Moeller-Trumbore intersector in TinyBVH used determinant-based critera to reject hits, e.g., `fabs( a ) < 1e-6` or `fabs( a ) < 1e-7`. The problem with this is that the determinant scales with the_ squared_ edge length of the triangle.

Small triangles can easily run into this, e.g., millimeter-scale detail in a scene modeled with meters as units. The Mitsuba test suite produced failures with this criterion were a standard Stanford Triangle mesh with 0.05 extent lost hits.

The problem is easy to reproduce with the following snippet:

```cpp
const float s = 2e-4f;
bvhvec4 verts[3] = { { 0, 0, 0, 0 }, { s, 0, 0, 0 }, { 0, s, 0, 0 } };
BVH bvh; bvh.Build( verts, 1 );
Ray r( bvhvec3( s / 3, s / 3, -1 ), bvhvec3( 0, 0, 1 ) );
bvh.Intersect( r ); // r.hit.t == BVH_FAR
```

This commit fixes the issue by rejecting only an exactly zero determinant.

As an additional robustness measure, I reformulated several tests as "NaN-safe" equivalent, e.g. `!(u >= 0 && v >= 0 && u + v <= 1)` instead of `u < 0 || v < 0 || u + v > 1`. Otherwise, these would have reported a success should a NaN ever slip through.