### PR TITLE
Fix float3/float4 mismatch in batch_cwbvh_any under SIMD_AABBTEST

### DIFF
--- a/kernels/traverse_cwbvh.cl
+++ b/kernels/traverse_cwbvh.cl
@@ -573,6 +573,10 @@ void kernel batch_cwbvh_any( global const float4* cwbvhNodes, global const float
 #endif
 	float tmax = 1e30f;
 	float4 hit = 0;
+#ifdef SIMD_AABBTEST
+	if (isoccluded_cwbvh( cwbvhNodes, cwbvhTris, O4, D4, rD4, tmax )) hit.w = 1;
+#else
 	if (isoccluded_cwbvh( cwbvhNodes, cwbvhTris, O4.xyz, D4.xyz, rD4.xyz, tmax )) hit.w = 1;
+#endif
 	rayData[threadId].hit = hit;
 }


### PR DESCRIPTION
`isoccluded_cwbvh()` is declared with `float4` parameters when `SIMD_AABBTEST` is defined and `float3` otherwise, but `batch_cwbvh_any()` places its call *after* the `#endif` and always passes `.xyz`. Building the OpenCL program therefore fails wherever `SIMD_AABBTEST` is enabled:

```
kernels/traverse_cwbvh.cl:576:47: error: passing '__private float3' (vector of 3 'float' values) to
parameter of incompatible type 'float4' (vector of 4 'float' values)
        if (isoccluded_cwbvh( cwbvhNodes, cwbvhTris, O4.xyz, D4.xyz, rD4.xyz, tmax )) hit.w = 1;
                                              ^~~~~~
kernels/traverse_cwbvh.cl:332:102: note: passing argument to parameter 'O' here
```

`traverse.cl` enables `SIMD_AABBTEST` for Intel and for the `#else // unkown GPU` fallback, so NVIDIA and AMD never reach it. Apple lands in the fallback, and because OpenCL compiles every kernel in the source, this breaks the whole program — including for users who only ever call the BVH2 kernels.

### The fix

Split the call across the two branches. This matches `batch_cwbvh()` directly above, and `traverse_tlas.cl`, which already does the same thing at its four call sites. The `float4` values are already prepared correctly in the block above (`O4.w = 1`, `D4.w = 0`, `rD4.w = 1`), so they only needed to be passed through rather than swizzled.

The `#else` branch is byte-identical to the previous line, so **nothing changes for NVIDIA or AMD**.

### Verification

On an Apple M1 Max (macOS 26.6.2, OpenCL 1.2), compiling `kernels/traverse.cl` via `clBuildProgram`:

| | result |
|---|---|
| `dev` @ d03231b | `BUILD FAILED` — the error above |
| this branch | `BUILD OK` |

I also ran this fix against `main` (1.8.0) in a real renderer, where `BVH_GPU` + the BVH2 `isoccluded` kernel now traverse correctly on Apple silicon at ~600 Mray/s.
