### PR TITLE
Add NEON/AVX2 traversal kernels for double precision ``BVH4_CPU``

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A constructed BVH can be used to intersect a ray with geometry, using ````BVH::I
 Apart from the default BVH layout (simply named ````BVH````), several other layouts are available, which all serve one or more specific purposes. You can create a BVH in the desired layout by instantiating the appropriate class. The available layouts are:
 * ````BVH```` : A compact format that stores the AABB for a node, along with child pointers and leaf information in a cross-platform-friendly way. The 32-byte size allows for cache-line alignment.
 * ````BVH_Double```` : Double-precision version of ````BVH````.
+* ````BVH4_Double```` : Double-precision version of ````BVH4_CPU````, with AVX2 and NEON traversal kernels.
 * ````MBVH<M>```` : In this (templated) format, each node stores _M_ child pointers, reducing the depth of the tree. This improves performance for divergent rays. Based on the [2008 paper](https://graphics.stanford.edu/~boulos/papers/multi_rt08.pdf) by Ingo Wald et al.
 * ````BVH4_CPU```` : SSE/NEON-optimized wide BVH traversal (["WiVe"](https://web.cs.ucdavis.edu/~hamann/FuetterlingLojewskiPfreundtHamannEbertHPG2017PaperFinal06222017.pdf)). The fastest option for CPUs that do not support AVX.
 * ````BVH8_CPU```` : AVX2-optimized wide BVH traversal (["WiVe"](https://web.cs.ucdavis.edu/~hamann/FuetterlingLojewskiPfreundtHamannEbertHPG2017PaperFinal06222017.pdf)). This is the fastest option on CPU.

--- a/examples/tiny_bvh_speedtest.cpp
+++ b/examples/tiny_bvh_speedtest.cpp
@@ -112,7 +112,7 @@ unsigned Nfull, Nsmall;
 Ray* fullBatch[3], * smallBatch[3], * smallDiffuse[3];
 Ray* shadowBatch[3];
 #ifdef DOUBLE_PRECISION_SUPPORT
-RayEx* doubleBatch[3];
+RayEx* doubleBatch[3], * doubleShadow[3], * doubleDiffuse[3];
 #endif
 
 // bvh layouts
@@ -122,6 +122,7 @@ BVH* sweepbvh = new BVH();
 BVH* ref_bvh = new BVH();
 BVH_Verbose* bvh_verbose = 0;
 BVH_Double* bvh_double = new BVH_Double();
+BVH4_Double* bvh4_double = 0;
 BVH_GPU* bvh_gpu = 0;
 MBVH<4>* bvh4 = 0;
 MBVH<8>* bvh8 = 0;
@@ -130,7 +131,6 @@ BVH4_GPU* bvh4_gpu = 0;
 BVH8_CWBVH* cwbvh = 0;
 BVH8_CPU* bvh8_cpu = 0;
 BVH8_CPU* bvh8_cpu_opt = 0;
-enum { _DEFAULT = 1, _BVH, _PRESPLIT, _SWEEP, _VERBOSE, _DOUBLE, _GPU2, _BVH4, _CPU4, _ALT4, _CPU4A, _CPU8, _OPT8, _GPU4, _BVH8, _CWBVH };
 
 #if defined _WIN32 || defined _WIN64
 #if defined EMBREE_BUILD || defined EMBREE_TRAVERSE
@@ -175,112 +175,33 @@ struct Timer
 	std::chrono::high_resolution_clock::time_point start;
 };
 
-float TestPrimaryRays( uint32_t layout, unsigned N, unsigned passes, float* avgCost = 0 )
+template <typename BVHType, typename RayType>
+float TestRays( const BVHType* bvh, RayType* batches[3], unsigned N, unsigned passes, float* avgCost = 0 )
 {
-	// Primary rays: coherent batch of rays from a pinhole camera. One ray per
-	// pixel, organized in tiles to further increase coherence.
+	// Traverse three batches of rays, which hold either primary rays (a coherent
+	// set from a pinhole camera, organized in tiles to further increase coherence)
+	// or diffuse rays (an incoherent set resulting from a diffuse bounce).
+	using Float = decltype( RayType::hit.t );
 	Timer t;
 	for (int view = 0; view < 3; view++)
-	{
-		Ray* batch = N == Nsmall ? smallBatch[view] : fullBatch[view];
-		for (unsigned i = 0; i < N; i++) batch[i].hit.t = 1e30f;
-	}
+		for (unsigned i = 0; i < N; i++) batches[view][i].hit.t = bvh_far<Float>;
 	uint32_t travCost = 0;
 	for (unsigned pass = 0; pass < passes + 1; pass++)
 	{
 		uint32_t view = pass == 0 ? 0 : (3 - pass); // 0, 2, 1, 0
-		Ray* batch = N == Nsmall ? smallBatch[view] : fullBatch[view];
+		RayType* batch = batches[view];
 		if (pass == 1)
 		{
-			Ray* batch = N == Nsmall ? smallBatch[0] : fullBatch[0];
-			for (unsigned i = 0; i < N; i++) batch[i].hit.t = 1e30f;
+			for (unsigned i = 0; i < N; i++) batches[0][i].hit.t = bvh_far<Float>;
 			t.reset(); // first pass is cache warming
 		}
-		switch (layout)
-		{
-		case _BVH: for (unsigned i = 0; i < N; i++) travCost += mybvh->Intersect( batch[i] ); break;
-		case _PRESPLIT: for (unsigned i = 0; i < N; i++) travCost += presplitbvh->Intersect( batch[i] ); break;
-		case _SWEEP: for (unsigned i = 0; i < N; i++) travCost += sweepbvh->Intersect( batch[i] ); break;
-		case _DEFAULT: for (unsigned i = 0; i < N; i++) travCost += ref_bvh->Intersect( batch[i] ); break;
-		case _GPU2: for (unsigned i = 0; i < N; i++) travCost += bvh_gpu->Intersect( batch[i] ); break;
-		case _GPU4: for (unsigned i = 0; i < N; i++) travCost += bvh4_gpu->Intersect( batch[i] ); break;
-		#if defined BVH_USESSE || defined BVH_USENEON
-		case _CPU4: for (unsigned i = 0; i < N; i++) travCost += bvh4_cpu->Intersect( batch[i] ); break;
-		#endif
-		#ifdef BVH_USEAVX
-		case _CWBVH: for (unsigned i = 0; i < N; i++) travCost += cwbvh->Intersect( batch[i] ); break;
-		case _CPU8: for (unsigned i = 0; i < N; i++) travCost += bvh8_cpu->Intersect( batch[i] ); break;
-		case _OPT8: for (unsigned i = 0; i < N; i++) travCost += bvh8_cpu_opt->Intersect( batch[i] ); break;
-		#endif
-		default: break;
-		};
+		for (unsigned i = 0; i < N; i++) travCost += bvh->Intersect( batch[i] );
 	}
 	if (avgCost) *avgCost = travCost / (float)(3 * N);
-	return t.elapsed() / passes;
-}
-
-float TestDiffuseRays( uint32_t layout, unsigned passes, float* avgCost = 0 )
-{
-	// Diffuse rays: incoherent batch of rays resulting from a diffuse bounce.
-	Timer t;
-	for (int view = 0; view < 3; view++)
-		for (unsigned i = 0; i < Nsmall; i++) smallDiffuse[view][i].hit.t = 1e30f;
-	uint32_t travCost = 0;
-	for (unsigned pass = 0; pass < passes + 1; pass++)
-	{
-		uint32_t view = pass == 0 ? 0 : (3 - pass); // 0, 2, 1, 0
-		Ray* batch = smallDiffuse[view];
-		if (pass == 1)
-		{
-			for (unsigned i = 0; i < Nsmall; i++) smallDiffuse[0][i].hit.t = 1e30f;
-			t.reset(); // first pass is cache warming
-		}
-		switch (layout)
-		{
-		case _BVH: for (unsigned i = 0; i < Nsmall; i++) travCost += mybvh->Intersect( batch[i] ); break;
-		case _PRESPLIT: for (unsigned i = 0; i < Nsmall; i++) travCost += presplitbvh->Intersect( batch[i] ); break;
-		case _SWEEP: for (unsigned i = 0; i < Nsmall; i++) travCost += sweepbvh->Intersect( batch[i] ); break;
-		case _DEFAULT: for (unsigned i = 0; i < Nsmall; i++) travCost += ref_bvh->Intersect( batch[i] ); break;
-		case _GPU2: for (unsigned i = 0; i < Nsmall; i++) travCost += bvh_gpu->Intersect( batch[i] ); break;
-		case _GPU4: for (unsigned i = 0; i < Nsmall; i++) travCost += bvh4_gpu->Intersect( batch[i] ); break;
-		#if defined BVH_USESSE || defined BVH_USENEON
-		case _CPU4: for (unsigned i = 0; i < Nsmall; i++) travCost += bvh4_cpu->Intersect( batch[i] ); break;
-		#endif
-		#ifdef BVH_USEAVX
-		case _CWBVH: for (unsigned i = 0; i < Nsmall; i++) travCost += cwbvh->Intersect( batch[i] ); break;
-		case _CPU8: for (unsigned i = 0; i < Nsmall; i++) travCost += bvh8_cpu->Intersect( batch[i] ); break;
-		case _OPT8: for (unsigned i = 0; i < Nsmall; i++) travCost += bvh8_cpu_opt->Intersect( batch[i] ); break;
-		#endif
-		default: break;
-		};
-	}
-	if (avgCost) *avgCost = travCost / (float)(3 * Nsmall);
 	return t.elapsed() / passes;
 }
 
 #ifdef DOUBLE_PRECISION_SUPPORT
-
-float TestPrimaryRaysEx( unsigned N, unsigned passes, float* avgCost = 0 )
-{
-	// Primary rays: coherent batch of rays from a pinhole camera.
-	// Double-precision version.
-	Timer t;
-	for (int view = 0; view < 3; view++)
-	{
-		RayEx* batch = doubleBatch[view];
-		for (unsigned i = 0; i < N; i++) batch[i].hit.t = 1e30f;
-	}
-	uint32_t travCost = 0;
-	for (unsigned pass = 0; pass < passes + 1; pass++)
-	{
-		uint32_t view = pass == 0 ? 0 : (3 - pass); // 0, 2, 1, 0
-		RayEx* batch = doubleBatch[view];
-		if (pass == 1) t.reset(); // first pass is cache warming
-		for (unsigned i = 0; i < N; i++) travCost += bvh_double->Intersect( batch[i] );
-	}
-	if (avgCost) *avgCost = travCost / (float)(3 * N);
-	return t.elapsed() / passes;
-}
 
 void ValidateTraceResultEx( float* ref, unsigned N, unsigned line )
 {
@@ -296,7 +217,8 @@ void ValidateTraceResultEx( float* ref, unsigned N, unsigned line )
 
 #endif
 
-float TestShadowRays( uint32_t layout, unsigned N, unsigned passes )
+template <typename BVHType, typename RayType>
+float TestShadowRays( const BVHType* bvh, RayType* batches[3], unsigned N, unsigned passes )
 {
 	// Shadow rays: coherent batch of rays from a single point to 'far away'. Shadow
 	// rays terminate on the first hit, and don't need sorted order. They also don't
@@ -307,22 +229,10 @@ float TestShadowRays( uint32_t layout, unsigned N, unsigned passes )
 	for (unsigned pass = 0; pass < passes + 1; pass++)
 	{
 		uint32_t view = pass == 0 ? 0 : (3 - pass); // 0, 2, 1, 0
-		Ray* batch = shadowBatch[view];
+		RayType* batch = batches[view];
 		if (pass == 1) t.reset(); // first pass is cache warming
 		occluded = 0;
-		switch (layout)
-		{
-		#if defined BVH_USESSE || defined BVH_USENEON
-		case _CPU4: for (unsigned i = 0; i < N; i++) occluded += bvh4_cpu->IsOccluded( batch[i] ); break;
-		#endif
-		#ifdef BVH_USEAVX2
-		case _CPU8: for (unsigned i = 0; i < N; i++) occluded += bvh8_cpu->IsOccluded( batch[i] ); break;
-		case _OPT8: for (unsigned i = 0; i < N; i++) occluded += bvh8_cpu_opt->IsOccluded( batch[i] ); break;
-		#endif
-		case _GPU2: for (unsigned i = 0; i < N; i++) occluded += bvh_gpu->IsOccluded( batch[i] ); break;
-		case _DEFAULT: for (unsigned i = 0; i < N; i++) occluded += mybvh->IsOccluded( batch[i] ); break;
-		default: break;
-		}
+		for (unsigned i = 0; i < N; i++) occluded += bvh->IsOccluded( batch[i] );
 	}
 	// Shadow ray validation: The compacted triangle format used by some intersection
 	// kernels will lead to some diverging results. We check if no more than about
@@ -419,7 +329,7 @@ void IntersectBvh256WorkerThread( int batchCount, Ray* fullBatch, int threadIdx 
 
 #endif
 
-#ifdef BVH_USEAVX
+#if defined TRAVERSE_2WAY_MT_PACKET && defined BVH_USEAVX
 
 void IntersectBvh256SSEWorkerThread( int batchCount, Ray* fullBatch, int threadIdx )
 {
@@ -523,6 +433,7 @@ int main()
 		smallDiffuse[i] = (Ray*)tinybvh::malloc64( SCRWIDTH * SCRHEIGHT * 2 * sizeof( Ray ) );
 	#ifdef DOUBLE_PRECISION_SUPPORT
 		doubleBatch[i] = (RayEx*)tinybvh::malloc64( SCRWIDTH * SCRHEIGHT * 2 * sizeof( RayEx ) );
+		doubleDiffuse[i] = (RayEx*)tinybvh::malloc64( SCRWIDTH * SCRHEIGHT * 2 * sizeof( RayEx ) );
 	#endif
 		for (int ty = 0; ty < SCRHEIGHT / 4; ty++) for (int tx = 0; tx < SCRWIDTH / 4; tx++)
 		{
@@ -585,6 +496,10 @@ int main()
 		}
 		else I = O + 20.0f * D;
 		smallDiffuse[i][j] = Ray( I + 0.001f * R, R );
+	#ifdef DOUBLE_PRECISION_SUPPORT
+		tinybvh::bvhdbl3 diffuseO = smallDiffuse[i][j].O, diffuseD = smallDiffuse[i][j].D;
+		doubleDiffuse[i][j] = RayEx( diffuseO, diffuseD );
+	#endif
 	}
 
 #ifdef BUILD_MIDPOINT
@@ -606,7 +521,7 @@ int main()
 	t.reset();
 	for (int pass = 0; pass < 3; pass++) mybvh->Build( triangles, verts / 3 );
 	buildTime = t.elapsed() / 3.0f;
-	TestPrimaryRays( _BVH, Nsmall, 3, &avgCost );
+	TestRays( mybvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "%7.2fms for %7i triangles ", buildTime * 1000.0f, verts / 3 );
 	printf( "- %6i nodes, SAH=%.2f, EPO=%.3f, rayCost=%.2f\n", mybvh->usedNodes, mybvh->SAHCost(), mybvh->EPOCost(), avgCost );
 
@@ -620,7 +535,7 @@ int main()
 	sweepbvh->settings.useFullSweep = true;
 	sweepbvh->Build( triangles, verts / 3 );
 	buildTime = t.elapsed();
-	TestPrimaryRays( _SWEEP, Nsmall, 3, &avgCost );
+	TestRays( sweepbvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "%7.2fms for %7i triangles ", buildTime * 1000.0f, verts / 3 );
 	printf( "- %6i nodes, SAH=%.2f, EPO=%.3f, rayCost=%.2f\n", sweepbvh->usedNodes, sweepbvh->SAHCost(), sweepbvh->EPOCost(), avgCost );
 
@@ -636,7 +551,7 @@ int main()
 	presplitbvh->settings.presplitPostPass = false;
 	for (int pass = 0; pass < 3; pass++) presplitbvh->Build( triangles, verts / 3 );
 	buildTime = t.elapsed() / 3.0f;
-	TestPrimaryRays( _PRESPLIT, Nsmall, 3, &avgCost );
+	TestRays( presplitbvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "%7.2fms for %7i triangles ", buildTime * 1000.0f, verts / 3 );
 	printf( "- %6i nodes, SAH=%.2f, EPO=%.3f, rayCost=%.2f\n", presplitbvh->usedNodes, presplitbvh->SAHCost(), presplitbvh->EPOCost(), avgCost );
 
@@ -652,7 +567,7 @@ int main()
 	presplitbvh->settings.presplitPostPass = true;
 	for (int pass = 0; pass < 3; pass++) presplitbvh->Build( triangles, verts / 3 );
 	buildTime = t.elapsed() / 3.0f;
-	TestPrimaryRays( _PRESPLIT, Nsmall, 3, &avgCost );
+	TestRays( presplitbvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "%7.2fms for %7i triangles ", buildTime * 1000.0f, verts / 3 );
 	printf( "- %6i nodes, SAH=%.2f, EPO=%.3f, rayCost=%.2f\n", presplitbvh->usedNodes, presplitbvh->SAHCost(), presplitbvh->EPOCost(), avgCost );
 
@@ -670,7 +585,7 @@ int main()
 		triEx[i].z = (double)triangles[i].z;
 	bvh_double->Build( triEx, verts / 3 );
 	buildTime = t.elapsed();
-	TestPrimaryRaysEx( Nsmall, 3, &avgCost );
+	TestRays( bvh_double, doubleBatch, Nsmall, 3, &avgCost );
 	printf( "%7.2fms for %7i triangles ", buildTime * 1000.0f, verts / 3 );
 	printf( "- %6i nodes, SAH=%.2f, rayCost=%.2f\n", (int)bvh_double->usedNodes, bvh_double->SAHCost(), avgCost );
 
@@ -683,7 +598,7 @@ int main()
 	t.reset();
 	for (int pass = 0; pass < 3; pass++) mybvh->BuildAVX( triangles, verts / 3 );
 	buildTime = t.elapsed() / 3.0f;
-	TestPrimaryRays( _BVH, Nsmall, 3, &avgCost );
+	TestRays( mybvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "%7.2fms for %7i triangles ", buildTime * 1000.0f, verts / 3 );
 	printf( "- %6i nodes, SAH=%.2f, EPO=%.3f, rayCost=%.2f\n", mybvh->usedNodes, mybvh->SAHCost(), mybvh->EPOCost(), avgCost );
 
@@ -698,7 +613,7 @@ int main()
 	mybvh->settings.usePresplitting = true;
 	for (int pass = 0; pass < 3; pass++) mybvh->BuildAVX( triangles, verts / 3 );
 	buildTime = t.elapsed() / 3.0f;
-	TestPrimaryRays( _BVH, Nsmall, 3, &avgCost );
+	TestRays( mybvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "%7.2fms for %7i triangles ", buildTime * 1000.0f, verts / 3 );
 	printf( "- %6i nodes, SAH=%.2f, EPO=%.3f, rayCost=%.2f\n", mybvh->usedNodes, mybvh->SAHCost(), mybvh->EPOCost(), avgCost );
 
@@ -711,7 +626,7 @@ int main()
 	t.reset();
 	for (int pass = 0; pass < 3; pass++) mybvh->BuildNEON( triangles, verts / 3 );
 	buildTime = t.elapsed() / 3.0f;
-	TestPrimaryRays( _BVH, Nsmall, 3, &avgCost );
+	TestRays( mybvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "%7.2fms for %7i triangles ", buildTime * 1000.0f, verts / 3 );
 	printf( "- %6i nodes, SAH=%.2f, rayCost=%.2f\n", mybvh->usedNodes, mybvh->SAHCost(), avgCost );
 
@@ -724,7 +639,7 @@ int main()
 	t.reset();
 	for (int pass = 0; pass < 2; pass++) mybvh->BuildHQ( triangles, verts / 3 );
 	buildTime = t.elapsed() / 2.0f;
-	TestPrimaryRays( _BVH, Nsmall, 3, &avgCost );
+	TestRays( mybvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "%7.2fms for %7i triangles ", buildTime * 1000.0f, verts / 3 );
 	printf( "- %6i nodes, SAH=%.2f, EPO=%.3f, rayCost=%.2f\n", mybvh->usedNodes, mybvh->SAHCost(), mybvh->EPOCost(), avgCost );
 
@@ -898,7 +813,7 @@ int main()
 	float shadowEpsilon = maxExtent * 5e-7f;
 
 	// setup proper shadow ray batch
-	traceTime = TestPrimaryRays( _DEFAULT, Nsmall, 1 ); // just to generate intersection points
+	traceTime = TestRays( ref_bvh, smallBatch, Nsmall, 1 ); // just to generate intersection points
 	for (int view = 0; view < 3; view++)
 	{
 		shadowBatch[view] = (Ray*)tinybvh::malloc64( sizeof( Ray ) * Nsmall );
@@ -910,6 +825,14 @@ int main()
 			bvhvec3 D = tinybvh_normalize( lightPos - I );
 			shadowBatch[view][i] = Ray( I + D * shadowEpsilon, D, tinybvh_length( lightPos - I ) - shadowEpsilon );
 		}
+	#ifdef DOUBLE_PRECISION_SUPPORT
+		doubleShadow[view] = (RayEx*)tinybvh::malloc64( sizeof( RayEx ) * Nsmall );
+		for (unsigned i = 0; i < Nsmall; i++)
+		{
+			tinybvh::bvhdbl3 O = shadowBatch[view][i].O, D = shadowBatch[view][i].D;
+			doubleShadow[view][i] = RayEx( O, D, shadowBatch[view][i].hit.t );
+		}
+	#endif
 		// get reference shadow ray query result
 		refOccluded[view] = 0, refOccl[view] = new unsigned[Nsmall];
 		for (unsigned i = 0; i < Nsmall; i++)
@@ -921,13 +844,13 @@ int main()
 	// WALD_32BYTE - Have this enabled at all times if validation is desired.
 	printf( "- BVH (plain) - primary: " );
 	PrepareTest();
-	traceTime = TestPrimaryRays( _DEFAULT, Nsmall, 3 );
+	traceTime = TestRays( mybvh, smallBatch, Nsmall, 3 );
 	// printf( "%4.2fM in %5.1fms (%7.2fMRays/s), ", (float)Nsmall * 1e-6f, traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "%7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestShadowRays( _DEFAULT, Nsmall, 3 );
+	traceTime = TestShadowRays( mybvh, shadowBatch, Nsmall, 3 );
 	// printf( "shadow: %5.1fms (%7.2fMRays/s)\n", traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "shadow: %7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestDiffuseRays( _DEFAULT, 3 );
+	traceTime = TestRays( mybvh, smallDiffuse, Nsmall, 3 );
 	printf( "diffuse: %7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
 
 #endif
@@ -942,14 +865,14 @@ int main()
 	}
 	printf( "- BVH_GPU     - primary: " );
 	PrepareTest();
-	traceTime = TestPrimaryRays( _GPU2, Nsmall, 3 );
+	traceTime = TestRays( bvh_gpu, smallBatch, Nsmall, 3 );
 	ValidateTraceResult( refDist, Nsmall, __LINE__ );
 	// printf( "%4.2fM rays in %5.1fms (%7.2fMRays/s), ", (float)Nsmall * 1e-6f, traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "%7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestShadowRays( _GPU2, Nsmall, 3 );
+	traceTime = TestShadowRays( bvh_gpu, shadowBatch, Nsmall, 3 );
 	// printf( "shadow: %5.1fms (%7.2fMRays/s)\n", traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "shadow: %7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestDiffuseRays( _GPU2, 3 );
+	traceTime = TestRays( bvh_gpu, smallDiffuse, Nsmall, 3 );
 	printf( "diffuse: %7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
 
 #endif
@@ -968,14 +891,14 @@ int main()
 	printf( "- BVH4 (SSE)  - primary: " );
 #endif
 	PrepareTest();
-	traceTime = TestPrimaryRays( _CPU4, Nsmall, 3 );
+	traceTime = TestRays( bvh4_cpu, smallBatch, Nsmall, 3 );
 	ValidateTraceResult( refDist, Nsmall, __LINE__ );
 	// printf( "%4.2fM rays in %5.1fms (%7.2fMRays/s), ", (float)Nsmall * 1e-6f, traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "%7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestShadowRays( _CPU4, Nsmall, 3 );
+	traceTime = TestShadowRays( bvh4_cpu, shadowBatch, Nsmall, 3 );
 	// printf( "shadow: %5.1fms (%7.2fMRays/s)\n", traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "shadow: %7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestDiffuseRays( _CPU4, 3 );
+	traceTime = TestRays( bvh4_cpu, smallDiffuse, Nsmall, 3 );
 	printf( "diffuse: %7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
 
 #endif
@@ -990,14 +913,14 @@ int main()
 	}
 	printf( "- BVH8 (AVX2) - primary: " );
 	PrepareTest();
-	traceTime = TestPrimaryRays( _CPU8, Nsmall, 3 );
+	traceTime = TestRays( bvh8_cpu, smallBatch, Nsmall, 3 );
 	ValidateTraceResult( refDist, Nsmall, __LINE__ );
 	// printf( "%4.2fM rays in %5.1fms (%7.2fMRays/s), ", (float)Nsmall * 1e-6f, traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "%7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestShadowRays( _CPU8, Nsmall, 3 );
+	traceTime = TestShadowRays( bvh8_cpu, shadowBatch, Nsmall, 3 );
 	// printf( "shadow: %5.1fms (%7.2fMRays/s)\n", traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "shadow: %7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestDiffuseRays( _CPU8, 3 );
+	traceTime = TestRays( bvh8_cpu, smallDiffuse, Nsmall, 3 );
 	printf( "diffuse: %7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
 
 	// If it is available, rerun with optimized BVH
@@ -1011,11 +934,11 @@ int main()
 		bvh8_cpu_opt->ConvertFrom( bvh8_cpu_opt->bvh8 );
 		PrepareTest();
 		printf( "- BVH8 (OPT)  - primary: " );
-		traceTime = TestPrimaryRays( _OPT8, Nsmall, 3 );
+		traceTime = TestRays( bvh8_cpu_opt, smallBatch, Nsmall, 3 );
 		printf( "%7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-		traceTime = TestShadowRays( _OPT8, Nsmall, 3 );
+		traceTime = TestShadowRays( bvh8_cpu_opt, shadowBatch, Nsmall, 3 );
 		printf( "shadow: %7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-		traceTime = TestDiffuseRays( _OPT8, 3 );
+		traceTime = TestRays( bvh8_cpu_opt, smallDiffuse, Nsmall, 3 );
 		printf( "diffuse: %7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
 	}
 
@@ -1026,10 +949,34 @@ int main()
 	// double-precision Rays/BVH
 	printf( "- BVH_DOUBLE  - primary: " );
 	PrepareTest();
-	traceTime = TestPrimaryRaysEx( Nsmall, 3 );
+	traceTime = TestRays( bvh_double, doubleBatch, Nsmall, 3 );
 	ValidateTraceResultEx( refDist, Nsmall, __LINE__ );
 	// printf( "%4.2fM rays in %5.1fms (%7.2fMRays/s)\n", (float)Nsmall * 1e-6f, traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
-	printf( "%7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
+	printf( "%7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
+	traceTime = TestShadowRays( bvh_double, doubleShadow, Nsmall, 3 );
+	printf( "shadow: %7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
+	traceTime = TestRays( bvh_double, doubleDiffuse, Nsmall, 3 );
+	printf( "diffuse: %7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
+
+#if defined BVH_USEAVX2 || defined BVH_USENEON
+
+	// BVH4_Double
+	if (!bvh4_double)
+	{
+		bvh4_double = new BVH4_Double();
+		bvh4_double->BuildHQ( triEx, verts / 3 );
+	}
+	printf( "- BVH4_DOUBLE - primary: " );
+	PrepareTest();
+	traceTime = TestRays( bvh4_double, doubleBatch, Nsmall, 3 );
+	ValidateTraceResultEx( refDist, Nsmall, __LINE__ );
+	printf( "%7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
+	traceTime = TestShadowRays( bvh4_double, doubleShadow, Nsmall, 3 );
+	printf( "shadow: %7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
+	traceTime = TestRays( bvh4_double, doubleDiffuse, Nsmall, 3 );
+	printf( "diffuse: %7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
+
+#endif
 
 #endif
 
@@ -1043,7 +990,7 @@ int main()
 		cwbvh->BuildHQ( triangles, verts / 3 );
 	}
 	printf( "- BVH8/CWBVH  - primary: " );
-	traceTime = TestPrimaryRays( _CWBVH, Nsmall, 3 );
+	traceTime = TestRays( cwbvh, smallBatch, Nsmall, 3 );
 	ValidateTraceResult( refDist, Nsmall, __LINE__ );
 	// printf( "%4.2fM rays in %5.1fms (%7.2fMRays/s)\n", (float)Nsmall * 1e-6f, traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "%7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
@@ -1060,7 +1007,7 @@ int main()
 	t.reset();
 	mybvh->Optimize( 50, true );
 	optimizeTime = t.elapsed();
-	TestPrimaryRays( _BVH, Nsmall, 3, &avgCost );
+	TestRays( mybvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "done (%.2fs). New: %i nodes, SAH=%.2f to %.2f, rayCost=%.2f\n", optimizeTime, mybvh->NodeCount(), prevSAH, mybvh->SAHCost(), avgCost );
 
 	printf( "Optimizing 'full-sweep' SAH BVH...        " );
@@ -1071,7 +1018,7 @@ int main()
 	t.reset();
 	mybvh->Optimize( 50, true );
 	optimizeTime = t.elapsed();
-	TestPrimaryRays( _BVH, Nsmall, 3, &avgCost );
+	TestRays( mybvh, smallBatch, Nsmall, 3, &avgCost );
 	printf( "done (%.2fs). New: %i nodes, SAH=%.2f to %.2f, rayCost=%.2f\n", optimizeTime, mybvh->NodeCount(), prevSAH, mybvh->SAHCost(), avgCost );
 	mybvh->settings.useFullSweep = false;
 
@@ -1086,14 +1033,14 @@ int main()
 	bvh8_cpu->Optimize( 50, true );
 	printf( "- BVH8_CPU    - primary: " );
 	PrepareTest();
-	traceTime = TestPrimaryRays( _CPU8, Nsmall, 3 );
+	traceTime = TestRays( bvh8_cpu, smallBatch, Nsmall, 3 );
 	ValidateTraceResult( refDist, Nsmall, __LINE__ );
 	// printf( "%4.2fM rays in %5.1fms (%7.2fMRays/s), ", (float)Nsmall * 1e-6f, traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "%7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestShadowRays( _CPU8, Nsmall, 3 );
+	traceTime = TestShadowRays( bvh8_cpu, shadowBatch, Nsmall, 3 );
 	// printf( "shadow: %5.1fms (%7.2fMRays/s)\n", traceTime * 1000, (float)Nsmall / traceTime * 1e-6f );
 	printf( "shadow: %7.2fMRays/s,  ", (float)Nsmall / traceTime * 1e-6f );
-	traceTime = TestDiffuseRays( _CPU8, 3 );
+	traceTime = TestRays( bvh8_cpu, smallDiffuse, Nsmall, 3 );
 	printf( "diffuse: %7.2fMRays/s\n", (float)Nsmall / traceTime * 1e-6f );
 
 #endif
@@ -1466,6 +1413,7 @@ int main()
 	delete ref_bvh;
 	delete bvh_verbose;
 	delete bvh_double;
+	delete bvh4_double;
 	delete bvh_gpu;
 	delete bvh4;
 	delete bvh8;

--- a/tests/tiny_bvh_axis_ray_test.cpp
+++ b/tests/tiny_bvh_axis_ray_test.cpp
@@ -194,9 +194,11 @@ int main()
 		TestRays<RayEx, bvhdbl3>( "BVH_Double::Build", bvh );
 		TestTLAS<BVH_Double, BLASInstanceEx, RayEx, bvhdbl3>( "TLAS over BVH_Double", &bvh );
 		bvh.BuildHQ( dverts.data(), triCount ), TestRays<RayEx, bvhdbl3>( "BVH_Double::BuildHQ", bvh );
-		// the wide layout instantiates for double precision too, with the scalar kernels.
-		impl::BVH4_CPU<double, uint64_t> bvh4;
-		bvh4.Build( dverts.data(), triCount ), TestRays<RayEx, bvhdbl3>( "BVH4_CPU<double>::Build", bvh4 );
+		BVH4_Double bvh4;
+		bvh4.Build( dverts.data(), triCount ), TestRays<RayEx, bvhdbl3>( "BVH4_Double::Build", bvh4 );
+		BVHBaseEx* blas4 = &bvh4;
+		TestTLAS<BVH_Double, BLASInstanceEx, RayEx, bvhdbl3>( "TLAS over BVH4_Double", blas4 );
+		bvh4.BuildHQ( dverts.data(), triCount ), TestRays<RayEx, bvhdbl3>( "BVH4_Double::BuildHQ", bvh4 );
 	}
 
 	if (g_failures) { printf( "%i axis-aligned ray test failures.\n", g_failures ); return 1; }

--- a/tests/tiny_bvh_simd_reference_test.cpp
+++ b/tests/tiny_bvh_simd_reference_test.cpp
@@ -2,8 +2,9 @@
 //
 // This file instantiates SIMD and scalar BVH implementations side by side and
 // compares them against each other. The scalar side uses the fact that the
-// platform headers specialize BVH<float, uint32_t> but not BVH<float, uint64_t>,
-// which therefore falls back to the scalar code.
+// platform headers specialize the <float, uint32_t> and <double, uint64_t>
+// instantiations but not <float, uint64_t> and <double, uint32_t>, which
+// therefore fall back to the scalar code.
 //
 // The trees are built with the reference builder on both sides, so that the
 // comparison is between kernels and not builders. The builders also have their
@@ -13,6 +14,7 @@
 // #define USE_DEPRECATED_LAYOUT // enables BVH_SoA
 #include "tiny_bvh.h"
 #include <cstdio>
+#include <type_traits>
 #include <vector>
 
 using namespace tinybvh;
@@ -26,6 +28,9 @@ using BVH8_CPUS = impl::BVH8_CPU<float, uint64_t>;
 #ifdef USE_DEPRECATED_LAYOUT
 using BVH_SoAS = impl::BVH_SoA<float, uint64_t>;
 #endif
+#ifdef DOUBLE_PRECISION_SUPPORT
+using BVH4_CPUDS = impl::BVH4_CPU<double, uint32_t>;
+#endif
 
 static constexpr float SCENE_SIZE = 10.0f;		// triangles and ray origins live in [0, SCENE_SIZE]^3
 static constexpr float T_TOLERANCE = 2e-5f;		// FMA versus separate multiply and add
@@ -38,6 +43,7 @@ static int g_failures = 0, g_testFailures = 0;
 struct Scene
 {
 	std::vector<bvhvec4> verts;		// three vertices per triangle, or the shared vertices of the grid
+	std::vector<bvhdbl3> dverts;	// the same vertices in double precision
 	std::vector<uint32_t> indices;	// empty for a triangle soup
 	std::vector<uint32_t> opmap;	// opacity micro maps, opmapN^2 bits per triangle
 	uint32_t triCount = 0, opmapN = 0;
@@ -53,6 +59,7 @@ static Scene MakeSoup( const uint32_t count, uint32_t seed )
 		const bvhvec3 c( tinybvh_rndfloat( seed ) * SCENE_SIZE, tinybvh_rndfloat( seed ) * SCENE_SIZE, tinybvh_rndfloat( seed ) * SCENE_SIZE );
 		for (int k = 0; k < 3; k++) s.verts.push_back( bvhvec4( c + tinybvh_rndvec3( seed ) * 0.5f, 0 ) );
 	}
+	for (const bvhvec4& v : s.verts) s.dverts.push_back( bvhdbl3( v ) );
 	return s;
 }
 
@@ -69,6 +76,7 @@ static Scene MakeGrid( const int res, uint32_t seed )
 		for (uint32_t t : tris) s.indices.push_back( t );
 	}
 	s.triCount = res * res * 2;
+	for (const bvhvec4& v : s.verts) s.dverts.push_back( bvhdbl3( v ) );
 	return s;
 }
 
@@ -83,22 +91,24 @@ static void AddOpacityMaps( Scene& s, const uint32_t N, uint32_t seed )
 template <class Acc> static void Build( Acc& acc, const Scene& s )
 {
 	acc.settings.useSIMDifavailable = false; // the reference builder gives both sides the same tree
-	if (s.indices.empty()) acc.Build( s.verts.data(), s.triCount );
-	else acc.Build( s.verts.data(), s.indices.data(), s.triCount );
+	const auto* verts = [&]() { if constexpr (std::is_same_v<typename Acc::Vertex, bvhvec4>) return s.verts.data(); else return s.dverts.data(); }();
+	if (s.indices.empty()) acc.Build( verts, s.triCount );
+	else acc.Build( verts, s.indices.data(), s.triCount );
 	if (s.opmapN) acc.SetOpacityMicroMaps( (uint32_t*)s.opmap.data(), s.opmapN );
 }
 
-static void Fail( const char* name, const char* what, const int ray, const float ta, const float tb, const uint64_t pa, const uint64_t pb )
+static void Fail( const char* name, const char* what, const int ray, const double ta, const double tb, const uint64_t pa, const uint64_t pb )
 {
 	g_failures++;
 	if (g_testFailures++ == 0)
 		printf( "FAIL: %s, %s, ray %i: SIMD t=%.7g prim=%llu, scalar t=%.7g prim=%llu\n", name, what, ray, ta, (unsigned long long)pa, tb, (unsigned long long)pb );
 }
 
-static bool SameHit( const float ta, const float tb, const uint64_t pa, const uint64_t pb )
+static bool SameHit( const double ta, const double tb, const uint64_t pa, const uint64_t pb )
 {
-	// same distance, or the same primitive with a rounding difference in t.
-	if (fabsf( ta - tb ) > T_TOLERANCE) return false;
+	// same distance, or the same primitive with a rounding difference in t. A miss is
+	// BVH_FAR or BVH_DBL_FAR, depending on the precision; neither is below BVH_FAR.
+	if (fabs( ta - tb ) > T_TOLERANCE) return false;
 	return pa == pb || (ta < BVH_FAR && tb < BVH_FAR);
 }
 
@@ -120,7 +130,7 @@ static void CompareRays( const char* name, const AccA& a, const AccB& b, const i
 		RayB rb( O, D );
 		a.Intersect( ra ), b.Intersect( rb );
 		if (!SameHit( ra.hit.t, rb.hit.t, ra.hit.prim, rb.hit.prim )) Fail( name, "Intersect", i, ra.hit.t, rb.hit.t, ra.hit.prim, rb.hit.prim );
-		else if (ra.hit.t < BVH_FAR && (fabsf( ra.hit.u - rb.hit.u ) > 1e-4f || fabsf( ra.hit.v - rb.hit.v ) > 1e-4f) && ra.hit.prim == rb.hit.prim)
+		else if (ra.hit.t < BVH_FAR && (fabs( ra.hit.u - rb.hit.u ) > 1e-4 || fabs( ra.hit.v - rb.hit.v ) > 1e-4) && ra.hit.prim == rb.hit.prim)
 			Fail( name, "Intersect barycentrics", i, ra.hit.u, rb.hit.u, ra.hit.prim, rb.hit.prim );
 		const RayA sa( O, D );
 		const RayB sb( O, D );
@@ -141,7 +151,7 @@ template <class AccA, class AccB> static void CompareLayouts( const char* name, 
 	AccA a;
 	AccB b;
 	Build( a, s ), Build( b, s );
-	CompareRays<Ray, RayS>( name, a, b );
+	CompareRays<typename AccA::Ray, typename AccB::Ray>( name, a, b );
 }
 
 // Instances: identity plus 90 degree rotations about each axis, spaced along z, as in the
@@ -164,18 +174,22 @@ template <class Inst> static void SetTransform( Inst& inst, int i )
 
 template <class AccA, class AccB> static void CompareTLAS( const char* name, const Scene& s )
 {
+	using BaseA = typename AccA::Base;
+	using BaseB = typename AccB::Base;
+	using InstA = typename BaseA::BLASInstance;
+	using InstB = typename BaseB::BLASInstance;
 	AccA a;
 	AccB b;
 	Build( a, s ), Build( b, s );
-	BLASInstance instA[INSTANCES];
-	BLASInstanceS instB[INSTANCES];
-	for (int i = 0; i < INSTANCES; i++) instA[i] = BLASInstance( 0 ), instB[i] = BLASInstanceS( 0 ), SetTransform( instA[i], i ), SetTransform( instB[i], i );
-	BVHBase* blasA = &a;
-	BVHBaseS* blasB = &b;
-	BVH tlasA;
-	BVHS tlasB;
+	InstA instA[INSTANCES];
+	InstB instB[INSTANCES];
+	for (int i = 0; i < INSTANCES; i++) instA[i] = InstA( 0 ), instB[i] = InstB( 0 ), SetTransform( instA[i], i ), SetTransform( instB[i], i );
+	BaseA* blasA = &a;
+	BaseB* blasB = &b;
+	typename BaseA::BVH tlasA;
+	typename BaseB::BVH tlasB;
 	tlasA.Build( instA, INSTANCES, &blasA, 1 ), tlasB.Build( instB, INSTANCES, &blasB, 1 );
-	CompareRays<Ray, RayS>( name, tlasA, tlasB, INSTANCES );
+	CompareRays<typename BaseA::Ray, typename BaseB::Ray>( name, tlasA, tlasB, INSTANCES );
 }
 
 // The SIMD builders against the reference builder: different trees, same closest hits.
@@ -252,6 +266,12 @@ int main()
 #ifdef USE_DEPRECATED_LAYOUT
 	CompareLayouts<BVH_SoA, BVH_SoAS>( "BVH_SoA, soup", soup );
 	CompareLayouts<BVH_SoA, BVH_SoAS>( "BVH_SoA, indexed grid", grid );
+#endif
+#ifdef DOUBLE_PRECISION_SUPPORT
+	CompareLayouts<BVH4_Double, BVH4_CPUDS>( "BVH4_Double, soup", soup );
+	CompareLayouts<BVH4_Double, BVH4_CPUDS>( "BVH4_Double, indexed grid", grid );
+	CompareLayouts<BVH4_Double, BVH4_CPUDS>( "BVH4_Double, opacity maps", mapped );
+	CompareTLAS<BVH4_Double, BVH4_CPUDS>( "TLAS over BVH4_Double", soup );
 #endif
 
 	// builders and packets

--- a/tiny_bvh.h
+++ b/tiny_bvh.h
@@ -361,6 +361,8 @@ template class impl::BLASInstance<float, uint32_t>;
 template class impl::BVHBase<double, uint64_t>;
 template class impl::BVH<double, uint64_t>;
 template class impl::BVH_Verbose<double, uint64_t>;
+template class impl::MBVH<4, double, uint64_t>;
+template class impl::BVH4_CPU<double, uint64_t>;
 template class impl::BLASInstance<double, uint64_t>;
 #endif
 

--- a/tiny_bvh_arm_double.h
+++ b/tiny_bvh_arm_double.h
@@ -1,8 +1,5 @@
 // tiny_bvh_arm_double.h: NEON specializations for the double precision layouts.
 // Included by tiny_bvh.h; do not include directly.
-//
-// There are no double precision SIMD kernels yet; BVH_Double uses the generic
-// code in tiny_bvh_base.h.
 
 #ifndef TINY_BVH_H_
 #error "Include tiny_bvh.h instead of tiny_bvh_arm_double.h."
@@ -11,4 +8,324 @@
 #ifndef TINY_BVH_ARM_DOUBLE_H_
 #define TINY_BVH_ARM_DOUBLE_H_
 
+#ifdef DOUBLE_PRECISION_SUPPORT
+
+namespace tinybvh {
+
+// Specializations provided by this header.
+template <> template <bool posX, bool posY, bool posZ> int32_t impl::BVH4_CPU<double, uint64_t>::IntersectOctant( Ray& ray ) const;
+template <> template <bool posX, bool posY, bool posZ> bool impl::BVH4_CPU<double, uint64_t>::IsOccludedOctant( const Ray& ray ) const;
+
+} // namespace tinybvh
+
+#endif // DOUBLE_PRECISION_SUPPORT
+
 #endif // TINY_BVH_ARM_DOUBLE_H_
+
+// ============================================================================
+//
+//        I M P L E M E N T A T I O N  -  A R M / N E O N  C O D E
+//
+// ============================================================================
+
+#if defined TINYBVH_IMPLEMENTATION && defined DOUBLE_PRECISION_SUPPORT
+
+namespace tinybvh {
+
+// BVH4_CPU<double> traversal, NEON version.
+// ----------------------------------------------------------------------------
+// Direct translation of the NEON single precision kernel. Every 4xFP32 operation
+// turns into a pair of 2xFP64 ones.
+
+// Narrow two 64-bit lane masks to one 32-bit lane mask.
+TINYBVH_FORCEINLINE uint32x4_t neon_narrow_mask( const uint64x2_t a, const uint64x2_t b )
+{
+	return vuzp1q_u32( vreinterpretq_u32_u64( a ), vreinterpretq_u32_u64( b ) );
+}
+
+// Truncating conversion of two double pairs to four 32-bit integers.
+TINYBVH_FORCEINLINE int32x4_t neon_cvt4_s32_f64( const float64x2_t a, const float64x2_t b )
+{
+	return vuzp1q_s32( vreinterpretq_s32_s64( vcvtq_s64_f64( a ) ), vreinterpretq_s32_s64( vcvtq_s64_f64( b ) ) );
+}
+
+#define NEON_HIT( s ) ((m64 >> (16 * s)) & 1)
+#define NEON_PUSH( c, l ) { nodeStack[stackPtr] = c; distStack[stackPtr] = tmin4[l]; stackPtr++; }
+
+template <> template <bool posX, bool posY, bool posZ> int32_t impl::BVH4_CPU<double, uint64_t>::IntersectOctant( Ray& ray ) const
+{
+	ALIGNED( 64 ) uint32_t nodeStack[TINYBVH_STACK_SIZE * 2 /* wide trees push more nodes per step */];
+	ALIGNED( 64 ) double distStack[TINYBVH_STACK_SIZE * 2];
+	ALIGNED( 16 ) double tmin4[4];
+	const float64x2_t zero2 = vdupq_n_f64( 0 ), one2 = vdupq_n_f64( 1 ), inf2 = vdupq_n_f64( BVH_DBL_FAR );
+	float64x2_t t2 = vdupq_n_f64( ray.hit.t );
+	int32_t stackPtr = 0;
+	uint32_t nodeIdx = 0;
+	double tcur = ray.hit.t;
+	constexpr int signShift = (posX ? 2 : 0) + (posY ? 4 : 0) + (posZ ? 8 : 0);
+	// the slab test computes bound * rD - O * rD using a fused multiply-add.
+	const float64x2_t rx2 = vdupq_n_f64( -ray.O.x * ray.rD.x ), rdx2 = vdupq_n_f64( ray.rD.x );
+	const float64x2_t ry2 = vdupq_n_f64( -ray.O.y * ray.rD.y ), rdy2 = vdupq_n_f64( ray.rD.y );
+	const float64x2_t rz2 = vdupq_n_f64( -ray.O.z * ray.rD.z ), rdz2 = vdupq_n_f64( ray.rD.z );
+	const float64x2_t ox2 = vdupq_n_f64( ray.O.x ), oy2 = vdupq_n_f64( ray.O.y ), oz2 = vdupq_n_f64( ray.O.z );
+	const float64x2_t dx2 = vdupq_n_f64( ray.D.x ), dy2 = vdupq_n_f64( ray.D.y ), dz2 = vdupq_n_f64( ray.D.z );
+	// constants that turn the 2-bit lane indices in perm4 into a byte shuffle
+	const uint32x4_t mul4 = vdupq_n_u32( 0x04040404 ), add4 = vdupq_n_u32( 0x03020100 );
+#ifdef _DEBUG
+	uint32_t steps = 0;
+#endif
+	while (1)
+	{
+	#ifdef _DEBUG
+		steps++;
+	#endif
+		while (!(nodeIdx & LEAF_BIT))
+		{
+			const BVHNode* n = (BVHNode*)(bvh4Data + nodeIdx);
+			const uint32_t* child = n->child, * perm = n->perm;
+			const double* xn = posX ? n->xmin : n->xmax, * xf = posX ? n->xmax : n->xmin;
+			const double* yn = posY ? n->ymin : n->ymax, * yf = posY ? n->ymax : n->ymin;
+			const double* zn = posZ ? n->zmin : n->zmax, * zf = posZ ? n->zmax : n->zmin;
+			const float64x2_t txa1 = vfmaq_f64( rx2, vld1q_f64( xn ), rdx2 ), txb1 = vfmaq_f64( rx2, vld1q_f64( xn + 2 ), rdx2 );
+			const float64x2_t tya1 = vfmaq_f64( ry2, vld1q_f64( yn ), rdy2 ), tyb1 = vfmaq_f64( ry2, vld1q_f64( yn + 2 ), rdy2 );
+			const float64x2_t tza1 = vfmaq_f64( rz2, vld1q_f64( zn ), rdz2 ), tzb1 = vfmaq_f64( rz2, vld1q_f64( zn + 2 ), rdz2 );
+			const float64x2_t txa2 = vfmaq_f64( rx2, vld1q_f64( xf ), rdx2 ), txb2 = vfmaq_f64( rx2, vld1q_f64( xf + 2 ), rdx2 );
+			const float64x2_t tya2 = vfmaq_f64( ry2, vld1q_f64( yf ), rdy2 ), tyb2 = vfmaq_f64( ry2, vld1q_f64( yf + 2 ), rdy2 );
+			const float64x2_t tza2 = vfmaq_f64( rz2, vld1q_f64( zf ), rdz2 ), tzb2 = vfmaq_f64( rz2, vld1q_f64( zf + 2 ), rdz2 );
+			const float64x2_t tmina = vmaxq_f64( vmaxq_f64( txa1, tya1 ), vmaxq_f64( tza1, zero2 ) );
+			const float64x2_t tminb = vmaxq_f64( vmaxq_f64( txb1, tyb1 ), vmaxq_f64( tzb1, zero2 ) );
+			const float64x2_t tmaxa = vminq_f64( vminq_f64( txa2, tya2 ), vminq_f64( tza2, t2 ) );
+			const float64x2_t tmaxb = vminq_f64( vminq_f64( txb2, tyb2 ), vminq_f64( tzb2, t2 ) );
+			const uint32x4_t mask4 = neon_narrow_mask( vcleq_f64( tmina, tmaxa ), vcleq_f64( tminb, tmaxb ) );
+			// The float kernel shuffles tmin into sorted order and pushes lane s of the result.
+			// A 64-bit shuffle across two registers is not worth it: tmin is stored as is, and
+			// a push reads the entry of the lane that holds its child.
+			vst1q_f64( tmin4, tmina ), vst1q_f64( tmin4 + 2, tminb );
+			// lane at each sorted position, and the child index stored in that lane
+			const uint32_t l3 = (perm[3] >> signShift) & 3, l2 = (perm[2] >> signShift) & 3;
+			const uint32_t l1 = (perm[1] >> signShift) & 3, l0 = (perm[0] >> signShift) & 3;
+			const uint32_t c3 = child[l3], c2 = child[l2], c1 = child[l1], c0 = child[l0];
+			// byte shuffle that brings the lanes into sorted order
+			const uint32x4_t perm4 = vld1q_u32( perm );
+			const uint32x4_t order4 = vshrq_n_u32( vshlq_n_u32( perm4, 30 - signShift ), 30 );
+			const uint8x16_t shfl16 = vreinterpretq_u8_u32( vmlaq_u32( add4, order4, mul4 ) );
+			// sorted slab mask, 16 bits per position
+			const uint32x4_t sorted4 = vreinterpretq_u32_u8( vqtbl1q_u8( vreinterpretq_u8_u32( mask4 ), shfl16 ) );
+			const uint64_t m64 = vget_lane_u64( vreinterpret_u64_u16( vshrn_n_u32( sorted4, 16 ) ), 0 );
+			// continue with the nearest valid child and push the others, farthest first
+			if (NEON_HIT( 3 ))
+			{
+				if (NEON_HIT( 0 )) NEON_PUSH( c0, l0 );
+				if (NEON_HIT( 1 )) NEON_PUSH( c1, l1 );
+				if (NEON_HIT( 2 )) NEON_PUSH( c2, l2 );
+				nodeIdx = c3;
+			}
+			else if (NEON_HIT( 2 ))
+			{
+				if (NEON_HIT( 0 )) NEON_PUSH( c0, l0 );
+				if (NEON_HIT( 1 )) NEON_PUSH( c1, l1 );
+				nodeIdx = c2;
+			}
+			else if (NEON_HIT( 1 ))
+			{
+				if (NEON_HIT( 0 )) NEON_PUSH( c0, l0 );
+				nodeIdx = c1;
+			}
+			else if (NEON_HIT( 0 )) nodeIdx = c0;
+			else
+			{
+				// skip entries behind the current hit
+				do { if (!stackPtr) goto the_end; nodeIdx = nodeStack[--stackPtr]; } while (distStack[stackPtr] > tcur);
+			}
+		}
+		// Moeller-Trumbore ray/triangle intersection algorithm for four triangles
+		const BVHTri4Leaf* leaf = (BVHTri4Leaf*)(bvh4Data + (nodeIdx & 0x1fffffff));
+		const float64x2_t e1xa = vld1q_f64( leaf->e1x ), e1ya = vld1q_f64( leaf->e1y ), e1za = vld1q_f64( leaf->e1z );
+		const float64x2_t e1xb = vld1q_f64( leaf->e1x + 2 ), e1yb = vld1q_f64( leaf->e1y + 2 ), e1zb = vld1q_f64( leaf->e1z + 2 );
+		const float64x2_t e2xa = vld1q_f64( leaf->e2x ), e2ya = vld1q_f64( leaf->e2y ), e2za = vld1q_f64( leaf->e2z );
+		const float64x2_t e2xb = vld1q_f64( leaf->e2x + 2 ), e2yb = vld1q_f64( leaf->e2y + 2 ), e2zb = vld1q_f64( leaf->e2z + 2 );
+		const float64x2_t hxa = vfmsq_f64( vmulq_f64( dy2, e2za ), dz2, e2ya ), hxb = vfmsq_f64( vmulq_f64( dy2, e2zb ), dz2, e2yb );
+		const float64x2_t hya = vfmsq_f64( vmulq_f64( dz2, e2xa ), dx2, e2za ), hyb = vfmsq_f64( vmulq_f64( dz2, e2xb ), dx2, e2zb );
+		const float64x2_t hza = vfmsq_f64( vmulq_f64( dx2, e2ya ), dy2, e2xa ), hzb = vfmsq_f64( vmulq_f64( dx2, e2yb ), dy2, e2xb );
+		const float64x2_t sxa = vsubq_f64( ox2, vld1q_f64( leaf->v0x ) ), sya = vsubq_f64( oy2, vld1q_f64( leaf->v0y ) ), sza = vsubq_f64( oz2, vld1q_f64( leaf->v0z ) );
+		const float64x2_t sxb = vsubq_f64( ox2, vld1q_f64( leaf->v0x + 2 ) ), syb = vsubq_f64( oy2, vld1q_f64( leaf->v0y + 2 ) ), szb = vsubq_f64( oz2, vld1q_f64( leaf->v0z + 2 ) );
+		const float64x2_t deta = vfmaq_f64( vfmaq_f64( vmulq_f64( e1ya, hya ), e1xa, hxa ), e1za, hza ), detb = vfmaq_f64( vfmaq_f64( vmulq_f64( e1yb, hyb ), e1xb, hxb ), e1zb, hzb );
+		const float64x2_t qza = vfmsq_f64( vmulq_f64( sxa, e1ya ), sya, e1xa ), qzb = vfmsq_f64( vmulq_f64( sxb, e1yb ), syb, e1xb );
+		const float64x2_t qxa = vfmsq_f64( vmulq_f64( sya, e1za ), sza, e1ya ), qxb = vfmsq_f64( vmulq_f64( syb, e1zb ), szb, e1yb );
+		const float64x2_t qya = vfmsq_f64( vmulq_f64( sza, e1xa ), sxa, e1za ), qyb = vfmsq_f64( vmulq_f64( szb, e1xb ), sxb, e1zb );
+		const float64x2_t inv_deta = vdivq_f64( one2, deta ), inv_detb = vdivq_f64( one2, detb );
+		const float64x2_t ua = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( sya, hya ), sxa, hxa ), sza, hza ), inv_deta );
+		const float64x2_t ub = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( syb, hyb ), sxb, hxb ), szb, hzb ), inv_detb );
+		const float64x2_t va = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( dy2, qya ), dx2, qxa ), dz2, qza ), inv_deta );
+		const float64x2_t vb = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( dy2, qyb ), dx2, qxb ), dz2, qzb ), inv_detb );
+		const float64x2_t taa = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( e2ya, qya ), e2xa, qxa ), e2za, qza ), inv_deta );
+		const float64x2_t tab = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( e2yb, qyb ), e2xb, qxb ), e2zb, qzb ), inv_detb );
+		const uint64x2_t mask1a = vandq_u64( vcgeq_f64( ua, zero2 ), vcgeq_f64( va, zero2 ) ), mask1b = vandq_u64( vcgeq_f64( ub, zero2 ), vcgeq_f64( vb, zero2 ) );
+		const uint64x2_t mask2a = vcleq_f64( vaddq_f64( ua, va ), one2 ), mask2b = vcleq_f64( vaddq_f64( ub, vb ), one2 );
+		const uint64x2_t mask3a = vandq_u64( vcltq_f64( taa, t2 ), vcgtq_f64( taa, zero2 ) ), mask3b = vandq_u64( vcltq_f64( tab, t2 ), vcgtq_f64( tab, zero2 ) );
+		uint64x2_t combineda = vandq_u64( vandq_u64( mask1a, mask2a ), mask3a ), combinedb = vandq_u64( vandq_u64( mask1b, mask2b ), mask3b );
+		uint32_t imask = neon_movemask_popc( neon_narrow_mask( combineda, combinedb ) ) & 15;
+		// evaluate opacity map, if present (NEON version).
+		if (opmap) if (imask)
+		{
+			const float64x2_t fN2 = vdupq_n_f64( (double)opmapN );
+			const int32x4_t row4 = neon_cvt4_s32_f64( vmulq_f64( vaddq_f64( ua, va ), fN2 ), vmulq_f64( vaddq_f64( ub, vb ), fN2 ) );
+			const int32x4_t dia4 = neon_cvt4_s32_f64( vmulq_f64( vsubq_f64( one2, ua ), fN2 ), vmulq_f64( vsubq_f64( one2, ub ), fN2 ) );
+			const int32x4_t v0 = vmulq_s32( row4, row4 );
+			const int32x4_t v1 = neon_cvt4_s32_f64( vmulq_f64( va, fN2 ), vmulq_f64( vb, fN2 ) );
+			const int32x4_t v2 = vsubq_s32( dia4, vsubq_s32( vdupq_n_s32( opmapN - 1 ), row4 ) );
+			uint32_t idx[4];
+			uint64_t omask[4] = { 0, 0, 0, 0 };
+			vst1q_u32( idx, vreinterpretq_u32_s32( vaddq_s32( vaddq_s32( v0, v1 ), v2 ) ) );
+			// gather the opacity bits with scalar loads
+			for (int i = 0; i < 4; i++) if (imask & (1 << i))
+			{
+				uint32_t* om = opmap + leaf->primIdx[i] * ((opmapN * opmapN + 31) >> 5);
+				if (om[idx[i] >> 5] & (1 << (idx[i] & 31))) omask[i] = ~0ull;
+			}
+			// combine
+			combineda = vandq_u64( combineda, vld1q_u64( omask ) ), combinedb = vandq_u64( combinedb, vld1q_u64( omask + 2 ) );
+			imask = neon_movemask_popc( neon_narrow_mask( combineda, combinedb ) ) & 15;
+		}
+		if (imask)
+		{
+			const float64x2_t dista = vbslq_f64( combineda, taa, inf2 ), distb = vbslq_f64( combinedb, tab, inf2 );
+			const double t = vminvq_f64( vminq_f64( dista, distb ) );
+			const uint32x4_t eq4 = neon_narrow_mask( vceqq_f64( dista, vdupq_n_f64( t ) ), vceqq_f64( distb, vdupq_n_f64( t ) ) );
+			const uint32_t lane = __bfind( neon_movemask_popc( eq4 ) & 15 );
+			// update hit record
+			ray.hit.t = t, ray.hit.u = tinybvh_getlane_d( lane < 2 ? &ua : &ub, lane & 1 ), ray.hit.v = tinybvh_getlane_d( lane < 2 ? &va : &vb, lane & 1 );
+			ray.SetHitPrim( leaf->primIdx[lane] );
+			t2 = vdupq_n_f64( t ), tcur = t;
+		}
+		// skip entries behind the current hit
+		do { if (!stackPtr) goto the_end; nodeIdx = nodeStack[--stackPtr]; } while (distStack[stackPtr] > tcur);
+	}
+the_end:
+#ifdef _DEBUG
+	return steps;
+#else
+	return 0;
+#endif
+}
+
+#undef NEON_PUSH
+#undef NEON_HIT
+#define NEON_HIT( l ) ((m64 >> (16 * l)) & 1)
+
+template <> template <bool posX, bool posY, bool posZ> bool impl::BVH4_CPU<double, uint64_t>::IsOccludedOctant( const Ray& ray ) const
+{
+	ALIGNED( 64 ) uint32_t nodeStack[TINYBVH_STACK_SIZE * 2 /* wide trees push more nodes per step */];
+	int32_t stackPtr = 0;
+	uint32_t nodeIdx = 0;
+	const float64x2_t zero2 = vdupq_n_f64( 0 ), one2 = vdupq_n_f64( 1 ), t2 = vdupq_n_f64( ray.hit.t );
+	const float64x2_t rx2 = vdupq_n_f64( -ray.O.x * ray.rD.x ), rdx2 = vdupq_n_f64( ray.rD.x );
+	const float64x2_t ry2 = vdupq_n_f64( -ray.O.y * ray.rD.y ), rdy2 = vdupq_n_f64( ray.rD.y );
+	const float64x2_t rz2 = vdupq_n_f64( -ray.O.z * ray.rD.z ), rdz2 = vdupq_n_f64( ray.rD.z );
+	const float64x2_t ox2 = vdupq_n_f64( ray.O.x ), oy2 = vdupq_n_f64( ray.O.y ), oz2 = vdupq_n_f64( ray.O.z );
+	const float64x2_t dx2 = vdupq_n_f64( ray.D.x ), dy2 = vdupq_n_f64( ray.D.y ), dz2 = vdupq_n_f64( ray.D.z );
+	while (1)
+	{
+		while (!(nodeIdx & LEAF_BIT))
+		{
+			const BVHNode* n = (BVHNode*)(bvh4Data + nodeIdx);
+			const uint32_t* child = n->child;
+			const double* xn = posX ? n->xmin : n->xmax, * xf = posX ? n->xmax : n->xmin;
+			const double* yn = posY ? n->ymin : n->ymax, * yf = posY ? n->ymax : n->ymin;
+			const double* zn = posZ ? n->zmin : n->zmax, * zf = posZ ? n->zmax : n->zmin;
+			const float64x2_t txa1 = vfmaq_f64( rx2, vld1q_f64( xn ), rdx2 ), txb1 = vfmaq_f64( rx2, vld1q_f64( xn + 2 ), rdx2 );
+			const float64x2_t tya1 = vfmaq_f64( ry2, vld1q_f64( yn ), rdy2 ), tyb1 = vfmaq_f64( ry2, vld1q_f64( yn + 2 ), rdy2 );
+			const float64x2_t tza1 = vfmaq_f64( rz2, vld1q_f64( zn ), rdz2 ), tzb1 = vfmaq_f64( rz2, vld1q_f64( zn + 2 ), rdz2 );
+			const float64x2_t txa2 = vfmaq_f64( rx2, vld1q_f64( xf ), rdx2 ), txb2 = vfmaq_f64( rx2, vld1q_f64( xf + 2 ), rdx2 );
+			const float64x2_t tya2 = vfmaq_f64( ry2, vld1q_f64( yf ), rdy2 ), tyb2 = vfmaq_f64( ry2, vld1q_f64( yf + 2 ), rdy2 );
+			const float64x2_t tza2 = vfmaq_f64( rz2, vld1q_f64( zf ), rdz2 ), tzb2 = vfmaq_f64( rz2, vld1q_f64( zf + 2 ), rdz2 );
+			const float64x2_t tmina = vmaxq_f64( vmaxq_f64( txa1, tya1 ), vmaxq_f64( tza1, zero2 ) );
+			const float64x2_t tminb = vmaxq_f64( vmaxq_f64( txb1, tyb1 ), vmaxq_f64( tzb1, zero2 ) );
+			const float64x2_t tmaxa = vminq_f64( vminq_f64( txa2, tya2 ), vminq_f64( tza2, t2 ) );
+			const float64x2_t tmaxb = vminq_f64( vminq_f64( txb2, tyb2 ), vminq_f64( tzb2, t2 ) );
+			const uint32x4_t mask4 = neon_narrow_mask( vcleq_f64( tmina, tmaxa ), vcleq_f64( tminb, tmaxb ) );
+			// slab mask, 16 bits per lane; the traversal order does not matter here
+			const uint64_t m64 = vget_lane_u64( vreinterpret_u64_u16( vshrn_n_u32( mask4, 16 ) ), 0 );
+			const uint32_t c0 = child[0], c1 = child[1], c2 = child[2], c3 = child[3];
+			if (NEON_HIT( 0 ))
+			{
+				if (NEON_HIT( 3 )) nodeStack[stackPtr++] = c3;
+				if (NEON_HIT( 2 )) nodeStack[stackPtr++] = c2;
+				if (NEON_HIT( 1 )) nodeStack[stackPtr++] = c1;
+				nodeIdx = c0;
+			}
+			else if (NEON_HIT( 1 ))
+			{
+				if (NEON_HIT( 3 )) nodeStack[stackPtr++] = c3;
+				if (NEON_HIT( 2 )) nodeStack[stackPtr++] = c2;
+				nodeIdx = c1;
+			}
+			else if (NEON_HIT( 2 ))
+			{
+				if (NEON_HIT( 3 )) nodeStack[stackPtr++] = c3;
+				nodeIdx = c2;
+			}
+			else if (NEON_HIT( 3 )) nodeIdx = c3;
+			else
+			{
+				if (!stackPtr) return false;
+				nodeIdx = nodeStack[--stackPtr];
+			}
+		}
+		// Moeller-Trumbore ray/triangle intersection algorithm for four triangles
+		const BVHTri4Leaf* leaf = (BVHTri4Leaf*)(bvh4Data + (nodeIdx & 0x1fffffff));
+		const float64x2_t e1xa = vld1q_f64( leaf->e1x ), e1ya = vld1q_f64( leaf->e1y ), e1za = vld1q_f64( leaf->e1z );
+		const float64x2_t e1xb = vld1q_f64( leaf->e1x + 2 ), e1yb = vld1q_f64( leaf->e1y + 2 ), e1zb = vld1q_f64( leaf->e1z + 2 );
+		const float64x2_t e2xa = vld1q_f64( leaf->e2x ), e2ya = vld1q_f64( leaf->e2y ), e2za = vld1q_f64( leaf->e2z );
+		const float64x2_t e2xb = vld1q_f64( leaf->e2x + 2 ), e2yb = vld1q_f64( leaf->e2y + 2 ), e2zb = vld1q_f64( leaf->e2z + 2 );
+		const float64x2_t hxa = vfmsq_f64( vmulq_f64( dy2, e2za ), dz2, e2ya ), hxb = vfmsq_f64( vmulq_f64( dy2, e2zb ), dz2, e2yb );
+		const float64x2_t hya = vfmsq_f64( vmulq_f64( dz2, e2xa ), dx2, e2za ), hyb = vfmsq_f64( vmulq_f64( dz2, e2xb ), dx2, e2zb );
+		const float64x2_t hza = vfmsq_f64( vmulq_f64( dx2, e2ya ), dy2, e2xa ), hzb = vfmsq_f64( vmulq_f64( dx2, e2yb ), dy2, e2xb );
+		const float64x2_t sxa = vsubq_f64( ox2, vld1q_f64( leaf->v0x ) ), sya = vsubq_f64( oy2, vld1q_f64( leaf->v0y ) ), sza = vsubq_f64( oz2, vld1q_f64( leaf->v0z ) );
+		const float64x2_t sxb = vsubq_f64( ox2, vld1q_f64( leaf->v0x + 2 ) ), syb = vsubq_f64( oy2, vld1q_f64( leaf->v0y + 2 ) ), szb = vsubq_f64( oz2, vld1q_f64( leaf->v0z + 2 ) );
+		const float64x2_t deta = vfmaq_f64( vfmaq_f64( vmulq_f64( e1ya, hya ), e1xa, hxa ), e1za, hza ), detb = vfmaq_f64( vfmaq_f64( vmulq_f64( e1yb, hyb ), e1xb, hxb ), e1zb, hzb );
+		const float64x2_t qza = vfmsq_f64( vmulq_f64( sxa, e1ya ), sya, e1xa ), qzb = vfmsq_f64( vmulq_f64( sxb, e1yb ), syb, e1xb );
+		const float64x2_t qxa = vfmsq_f64( vmulq_f64( sya, e1za ), sza, e1ya ), qxb = vfmsq_f64( vmulq_f64( syb, e1zb ), szb, e1yb );
+		const float64x2_t qya = vfmsq_f64( vmulq_f64( sza, e1xa ), sxa, e1za ), qyb = vfmsq_f64( vmulq_f64( szb, e1xb ), sxb, e1zb );
+		const float64x2_t inv_deta = vdivq_f64( one2, deta ), inv_detb = vdivq_f64( one2, detb );
+		const float64x2_t ua = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( sya, hya ), sxa, hxa ), sza, hza ), inv_deta );
+		const float64x2_t ub = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( syb, hyb ), sxb, hxb ), szb, hzb ), inv_detb );
+		const float64x2_t va = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( dy2, qya ), dx2, qxa ), dz2, qza ), inv_deta );
+		const float64x2_t vb = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( dy2, qyb ), dx2, qxb ), dz2, qzb ), inv_detb );
+		const float64x2_t taa = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( e2ya, qya ), e2xa, qxa ), e2za, qza ), inv_deta );
+		const float64x2_t tab = vmulq_f64( vfmaq_f64( vfmaq_f64( vmulq_f64( e2yb, qyb ), e2xb, qxb ), e2zb, qzb ), inv_detb );
+		const uint64x2_t mask1a = vandq_u64( vcgeq_f64( ua, zero2 ), vcgeq_f64( va, zero2 ) ), mask1b = vandq_u64( vcgeq_f64( ub, zero2 ), vcgeq_f64( vb, zero2 ) );
+		const uint64x2_t mask2a = vcleq_f64( vaddq_f64( ua, va ), one2 ), mask2b = vcleq_f64( vaddq_f64( ub, vb ), one2 );
+		const uint64x2_t mask3a = vandq_u64( vcltq_f64( taa, t2 ), vcgtq_f64( taa, zero2 ) ), mask3b = vandq_u64( vcltq_f64( tab, t2 ), vcgtq_f64( tab, zero2 ) );
+		const uint64x2_t combineda = vandq_u64( vandq_u64( mask1a, mask2a ), mask3a ), combinedb = vandq_u64( vandq_u64( mask1b, mask2b ), mask3b );
+		const uint32_t imask = neon_movemask_popc( neon_narrow_mask( combineda, combinedb ) ) & 15;
+		if (imask)
+		{
+			if (!opmap) return true;
+			// evaluate opacity map, NEON version.
+			const float64x2_t fN2 = vdupq_n_f64( (double)opmapN );
+			const int32x4_t row4 = neon_cvt4_s32_f64( vmulq_f64( vaddq_f64( ua, va ), fN2 ), vmulq_f64( vaddq_f64( ub, vb ), fN2 ) );
+			const int32x4_t dia4 = neon_cvt4_s32_f64( vmulq_f64( vsubq_f64( one2, ua ), fN2 ), vmulq_f64( vsubq_f64( one2, ub ), fN2 ) );
+			const int32x4_t v0 = vmulq_s32( row4, row4 );
+			const int32x4_t v1 = neon_cvt4_s32_f64( vmulq_f64( va, fN2 ), vmulq_f64( vb, fN2 ) );
+			const int32x4_t v2 = vsubq_s32( dia4, vsubq_s32( vdupq_n_s32( opmapN - 1 ), row4 ) );
+			uint32_t idx[4];
+			vst1q_u32( idx, vreinterpretq_u32_s32( vaddq_s32( vaddq_s32( v0, v1 ), v2 ) ) );
+			// gather the opacity bits with scalar loads
+			for (int i = 0; i < 4; i++) if (imask & (1 << i))
+			{
+				uint32_t* om = opmap + leaf->primIdx[i] * ((opmapN * opmapN + 31) >> 5);
+				if (om[idx[i] >> 5] & (1 << (idx[i] & 31))) return true;
+			}
+		}
+		// we continue.
+		if (!stackPtr) return false;
+		nodeIdx = nodeStack[--stackPtr];
+	}
+}
+
+#undef NEON_HIT
+
+} // namespace tinybvh
+
+#endif // TINYBVH_IMPLEMENTATION && DOUBLE_PRECISION_SUPPORT

--- a/tiny_bvh_base.h
+++ b/tiny_bvh_base.h
@@ -191,6 +191,10 @@ TINYBVH_FORCEINLINE void tinybvh_setlane_f( void* v, const size_t lane, const fl
 {
 	memcpy( (char*)v + lane * 4, &f, 4 );
 }
+TINYBVH_FORCEINLINE double tinybvh_getlane_d( const void* v, const size_t lane )
+{
+	double d; memcpy( &d, (const char*)v + lane * 8, 8 ); return d;
+}
 TINYBVH_FORCEINLINE uint32_t tinybvh_getlane_u( const void* v, const size_t lane )
 {
 	uint32_t u; memcpy( &u, (const char*)v + lane * 4, 4 ); return u;
@@ -451,7 +455,7 @@ template <> struct bvh_traits<float>
 	using vertex = bvhvec4;		// vertex storage: 16 bytes per vertex, w unused
 	using slice = bvhvec4slice;
 	using mat4 = bvhmat4;
-	static constexpr bool wide_layouts = true;	// BVH4_CPU, and BVH8_CPU exist for this scalar type.
+	static constexpr bool wide_layouts = true;	// BVH4_CPU and BVH8_CPU can be attached to a TLAS.
 };
 #ifdef DOUBLE_PRECISION_SUPPORT
 template <> struct bvh_traits<double>
@@ -460,7 +464,7 @@ template <> struct bvh_traits<double>
 	using vertex = bvhdbl3;		// vertex storage: 24 bytes per vertex
 	using slice = bvhdbl3slice;
 	using mat4 = bvhdblmat4;
-	static constexpr bool wide_layouts = false;
+	static constexpr bool wide_layouts = true;
 };
 #endif
 
@@ -1276,8 +1280,8 @@ public:
 	enum { EMPTY_BIT = 1 << 31, LEAF_BIT = 1 << 30 };
 	struct ALIGNED( 64 ) BVHNode
 	{
-		// 4-way BVH node, optimized for CPU rendering. The SSE and NEON kernels load the
-		// bounds of the four children as vectors; the layout is 128 bytes for float.
+		// 4-way BVH node, optimized for CPU rendering. The SIMD kernels load the bounds of
+		// the four children as vectors; the layout is 128 bytes for float, 256 for double.
 		Float xmin[4], xmax[4];
 		Float ymin[4], ymax[4];
 		Float zmin[4], zmax[4];
@@ -1379,7 +1383,7 @@ template <typename Float, typename Index> struct ALIGNED( 64 ) BVHTri4Leaf
 	Float v0x[4], v0y[4], v0z[4];
 	Float e1x[4], e1y[4], e1z[4];
 	Float e2x[4], e2y[4], e2z[4];
-	Index primIdx[4];			// total: 160 bytes for float, padded to 3 full cachelines.
+	Index primIdx[4];			// total: 160 bytes for float (padded to 192), 320 bytes for double.
 	inline void SetData( const Vec3& v0, const Vec3& e1, const Vec3& e2, const Index pidx, const uint32_t slot )
 	{
 		v0x[slot] = v0.x, v0y[slot] = v0.y, v0z[slot] = v0.z;
@@ -1543,6 +1547,7 @@ using IntersectionEx = impl::Intersection<double, uint64_t>;
 using RayEx = impl::Ray<double, uint64_t>;
 using BVHBaseEx = impl::BVHBase<double, uint64_t>;
 using BVH_Double = impl::BVH<double, uint64_t>;
+using BVH4_Double = impl::BVH4_CPU<double, uint64_t>;
 using BLASInstanceEx = impl::BLASInstance<double, uint64_t>;
 #endif
 

--- a/tiny_bvh_x86_double.h
+++ b/tiny_bvh_x86_double.h
@@ -1,8 +1,5 @@
-// tiny_bvh_x86_double.h: SSE / AVX specializations for the double precision layouts.
+// tiny_bvh_x86_double.h: AVX2 specializations for the double precision layouts.
 // Included by tiny_bvh.h; do not include directly.
-//
-// There are no double precision SIMD kernels yet; BVH_Double uses the generic
-// code in tiny_bvh_base.h.
 
 #ifndef TINY_BVH_H_
 #error "Include tiny_bvh.h instead of tiny_bvh_x86_double.h."
@@ -11,4 +8,276 @@
 #ifndef TINY_BVH_X86_DOUBLE_H_
 #define TINY_BVH_X86_DOUBLE_H_
 
+#if defined DOUBLE_PRECISION_SUPPORT && defined BVH_USEAVX2
+
+namespace tinybvh {
+
+// Specializations provided by this header.
+template <> template <bool posX, bool posY, bool posZ> int32_t impl::BVH4_CPU<double, uint64_t>::IntersectOctant( Ray& ray ) const;
+template <> template <bool posX, bool posY, bool posZ> bool impl::BVH4_CPU<double, uint64_t>::IsOccludedOctant( const Ray& ray ) const;
+
+} // namespace tinybvh
+
+#endif // DOUBLE_PRECISION_SUPPORT && BVH_USEAVX2
+
 #endif // TINY_BVH_X86_DOUBLE_H_
+
+// ============================================================================
+//
+//        I M P L E M E N T A T I O N  -  A V X 2  C O D E
+//
+// ============================================================================
+
+#if defined TINYBVH_IMPLEMENTATION && defined DOUBLE_PRECISION_SUPPORT && defined BVH_USEAVX2
+
+namespace tinybvh {
+
+// BVH4_CPU<double> traversal, AVX2 version.
+// ----------------------------------------------------------------------------
+// Direct translation of the single precision SSE kernel to 256-bit registers.
+
+#define AVX_HIT( l ) ((m >> l) & 1)
+#define AVX_PUSH( c, l ) { nodeStack[stackPtr] = c; distStack[stackPtr] = tmin4[l]; stackPtr++; }
+
+template <> template <bool posX, bool posY, bool posZ> int32_t impl::BVH4_CPU<double, uint64_t>::IntersectOctant( Ray& ray ) const
+{
+	ALIGNED( 64 ) uint32_t nodeStack[TINYBVH_STACK_SIZE * 2 /* wide trees push more nodes per step */];
+	ALIGNED( 64 ) double distStack[TINYBVH_STACK_SIZE * 2];
+	ALIGNED( 32 ) double tmin4[4];
+	const __m256d zero4 = _mm256_setzero_pd();
+	__m256d t4 = _mm256_set1_pd( ray.hit.t );
+	int32_t stackPtr = 0;
+	uint32_t nodeIdx = 0;
+	double tcur = ray.hit.t;
+	constexpr int signShift = (posX ? 2 : 0) + (posY ? 4 : 0) + (posZ ? 8 : 0);
+	const __m256d rx4 = _mm256_set1_pd( ray.O.x * ray.rD.x ), rdx4 = _mm256_set1_pd( ray.rD.x );
+	const __m256d ry4 = _mm256_set1_pd( ray.O.y * ray.rD.y ), rdy4 = _mm256_set1_pd( ray.rD.y );
+	const __m256d rz4 = _mm256_set1_pd( ray.O.z * ray.rD.z ), rdz4 = _mm256_set1_pd( ray.rD.z );
+	const __m256d ox4 = _mm256_set1_pd( ray.O.x ), oy4 = _mm256_set1_pd( ray.O.y ), oz4 = _mm256_set1_pd( ray.O.z );
+	const __m256d dx4 = _mm256_set1_pd( ray.D.x ), dy4 = _mm256_set1_pd( ray.D.y ), dz4 = _mm256_set1_pd( ray.D.z );
+	const __m256d one4 = _mm256_set1_pd( 1 ), inf4 = _mm256_set1_pd( BVH_DBL_FAR );
+#ifdef _DEBUG
+	uint32_t steps = 0;
+#endif
+	while (1)
+	{
+	#ifdef _DEBUG
+		steps++;
+	#endif
+		while (!(nodeIdx & LEAF_BIT))
+		{
+			const BVHNode* n = (BVHNode*)(bvh4Data + nodeIdx);
+			const uint32_t* child = n->child, * perm = n->perm;
+			const __m256d tx1 = _mm256_fmsub_pd( _mm256_load_pd( posX ? n->xmin : n->xmax ), rdx4, rx4 );
+			const __m256d ty1 = _mm256_fmsub_pd( _mm256_load_pd( posY ? n->ymin : n->ymax ), rdy4, ry4 );
+			const __m256d tz1 = _mm256_fmsub_pd( _mm256_load_pd( posZ ? n->zmin : n->zmax ), rdz4, rz4 );
+			const __m256d tx2 = _mm256_fmsub_pd( _mm256_load_pd( posX ? n->xmax : n->xmin ), rdx4, rx4 );
+			const __m256d ty2 = _mm256_fmsub_pd( _mm256_load_pd( posY ? n->ymax : n->ymin ), rdy4, ry4 );
+			const __m256d tz2 = _mm256_fmsub_pd( _mm256_load_pd( posZ ? n->zmax : n->zmin ), rdz4, rz4 );
+			const __m256d tmin = _mm256_max_pd( _mm256_max_pd( zero4, tx1 ), _mm256_max_pd( ty1, tz1 ) );
+			const __m256d tmax = _mm256_min_pd( _mm256_min_pd( tx2, t4 ), _mm256_min_pd( ty2, tz2 ) );
+			// The SSE kernel permutes the slab mask and tmin into sorted order, so that the
+			// ladder below tests bit s and pushes lane s. AVX2 has no variable cross-lane
+			// permute for 64-bit lanes, so both stay in lane order here and the ladder uses
+			// the lane number of each sorted position, which it needs for the child index anyway.
+			const uint32_t m = _mm256_movemask_pd( _mm256_cmp_pd( tmin, tmax, _CMP_LE_OQ ) );
+			_mm256_store_pd( tmin4, tmin );
+			// lane at each sorted position, and the child index stored in that lane
+			const uint32_t l3 = (perm[3] >> signShift) & 3, l2 = (perm[2] >> signShift) & 3;
+			const uint32_t l1 = (perm[1] >> signShift) & 3, l0 = (perm[0] >> signShift) & 3;
+			const uint32_t c3 = child[l3], c2 = child[l2], c1 = child[l1], c0 = child[l0];
+			// continue with the nearest valid child and push the others, farthest first
+			if (AVX_HIT( l3 ))
+			{
+				if (AVX_HIT( l0 )) AVX_PUSH( c0, l0 );
+				if (AVX_HIT( l1 )) AVX_PUSH( c1, l1 );
+				if (AVX_HIT( l2 )) AVX_PUSH( c2, l2 );
+				nodeIdx = c3;
+			}
+			else if (AVX_HIT( l2 ))
+			{
+				if (AVX_HIT( l0 )) AVX_PUSH( c0, l0 );
+				if (AVX_HIT( l1 )) AVX_PUSH( c1, l1 );
+				nodeIdx = c2;
+			}
+			else if (AVX_HIT( l1 ))
+			{
+				if (AVX_HIT( l0 )) AVX_PUSH( c0, l0 );
+				nodeIdx = c1;
+			}
+			else if (AVX_HIT( l0 )) nodeIdx = c0;
+			else
+			{
+				// skip entries behind the current hit
+				do { if (!stackPtr) goto the_end; nodeIdx = nodeStack[--stackPtr]; } while (distStack[stackPtr] > tcur);
+			}
+		}
+		// Moeller-Trumbore ray/triangle intersection algorithm for four triangles
+		const BVHTri4Leaf* leaf = (BVHTri4Leaf*)(bvh4Data + (nodeIdx & 0x1fffffff));
+		const __m256d hx4 = _mm256_fmsub_pd( dy4, _mm256_load_pd( leaf->e2z ), _mm256_mul_pd( dz4, _mm256_load_pd( leaf->e2y ) ) );
+		const __m256d hy4 = _mm256_fmsub_pd( dz4, _mm256_load_pd( leaf->e2x ), _mm256_mul_pd( dx4, _mm256_load_pd( leaf->e2z ) ) );
+		const __m256d hz4 = _mm256_fmsub_pd( dx4, _mm256_load_pd( leaf->e2y ), _mm256_mul_pd( dy4, _mm256_load_pd( leaf->e2x ) ) );
+		const __m256d sx4 = _mm256_sub_pd( ox4, _mm256_load_pd( leaf->v0x ) ), sy4 = _mm256_sub_pd( oy4, _mm256_load_pd( leaf->v0y ) ), sz4 = _mm256_sub_pd( oz4, _mm256_load_pd( leaf->v0z ) );
+		const __m256d det4 = _mm256_fmadd_pd( _mm256_load_pd( leaf->e1z ), hz4, _mm256_fmadd_pd( _mm256_load_pd( leaf->e1x ), hx4, _mm256_mul_pd( _mm256_load_pd( leaf->e1y ), hy4 ) ) );
+		const __m256d qz4 = _mm256_fmsub_pd( sx4, _mm256_load_pd( leaf->e1y ), _mm256_mul_pd( sy4, _mm256_load_pd( leaf->e1x ) ) );
+		const __m256d qx4 = _mm256_fmsub_pd( sy4, _mm256_load_pd( leaf->e1z ), _mm256_mul_pd( sz4, _mm256_load_pd( leaf->e1y ) ) );
+		const __m256d qy4 = _mm256_fmsub_pd( sz4, _mm256_load_pd( leaf->e1x ), _mm256_mul_pd( sx4, _mm256_load_pd( leaf->e1z ) ) );
+		const __m256d inv_det4 = _mm256_div_pd( one4, det4 );
+		const __m256d u4 = _mm256_mul_pd( _mm256_fmadd_pd( sz4, hz4, _mm256_fmadd_pd( sx4, hx4, _mm256_mul_pd( sy4, hy4 ) ) ), inv_det4 );
+		const __m256d v4 = _mm256_mul_pd( _mm256_fmadd_pd( dz4, qz4, _mm256_fmadd_pd( dx4, qx4, _mm256_mul_pd( dy4, qy4 ) ) ), inv_det4 );
+		const __m256d ta4 = _mm256_mul_pd( _mm256_fmadd_pd( _mm256_load_pd( leaf->e2z ), qz4, _mm256_fmadd_pd( _mm256_load_pd( leaf->e2x ), qx4, _mm256_mul_pd( _mm256_load_pd( leaf->e2y ), qy4 ) ) ), inv_det4 );
+		const __m256d mask1 = _mm256_and_pd( _mm256_cmp_pd( u4, zero4, _CMP_GE_OQ ), _mm256_cmp_pd( v4, zero4, _CMP_GE_OQ ) );
+		const __m256d mask2 = _mm256_cmp_pd( _mm256_add_pd( u4, v4 ), one4, _CMP_LE_OQ );
+		const __m256d mask3 = _mm256_and_pd( _mm256_cmp_pd( ta4, t4, _CMP_LT_OQ ), _mm256_cmp_pd( ta4, zero4, _CMP_GT_OQ ) );
+		__m256d combined = _mm256_and_pd( _mm256_and_pd( mask1, mask2 ), mask3 );
+		uint32_t imask = _mm256_movemask_pd( combined );
+		// evaluate opacity map, if present (AVX2 version).
+		if (opmap) if (imask)
+		{
+			const __m256d fN4 = _mm256_set1_pd( (double)opmapN );
+			const __m128i row4 = _mm256_cvttpd_epi32( _mm256_mul_pd( _mm256_add_pd( u4, v4 ), fN4 ) );
+			const __m128i dia4 = _mm256_cvttpd_epi32( _mm256_mul_pd( _mm256_sub_pd( one4, u4 ), fN4 ) );
+			const __m128i v0 = _mm_mullo_epi32( row4, row4 );
+			const __m128i v1 = _mm256_cvttpd_epi32( _mm256_mul_pd( v4, fN4 ) );
+			const __m128i v2 = _mm_sub_epi32( dia4, _mm_sub_epi32( _mm_set1_epi32( opmapN - 1 ), row4 ) );
+			uint32_t idx[4];
+			uint64_t omask[4] = { 0, 0, 0, 0 };
+			tinybvh_store4i( idx, _mm_add_epi32( _mm_add_epi32( v0, v1 ), v2 ) );
+			// gather the opacity bits with scalar loads
+			for (int i = 0; i < 4; i++) if (imask & (1 << i))
+			{
+				uint32_t* om = opmap + leaf->primIdx[i] * ((opmapN * opmapN + 31) >> 5);
+				if (om[idx[i] >> 5] & (1 << (idx[i] & 31))) omask[i] = ~0ull;
+			}
+			// combine
+			combined = _mm256_and_pd( combined, _mm256_castsi256_pd( tinybvh_load8i( omask ) ) );
+			imask = _mm256_movemask_pd( combined );
+		}
+		if (imask)
+		{
+			const __m256d dist4 = _mm256_blendv_pd( inf4, ta4, combined );
+			// compute broadcasted horizontal minimum of dist4
+			const __m256d a = _mm256_min_pd( dist4, _mm256_permute2f128_pd( dist4, dist4, 1 ) );
+			const __m256d c = _mm256_min_pd( a, _mm256_permute_pd( a, 5 ) );
+			const uint32_t lane = __bfind( _mm256_movemask_pd( _mm256_cmp_pd( c, dist4, _CMP_EQ_OQ ) ) );
+			// update hit record
+			const double t = _mm256_cvtsd_f64( c );
+			ray.hit.t = t, ray.hit.u = tinybvh_getlane_d( &u4, lane ), ray.hit.v = tinybvh_getlane_d( &v4, lane );
+			ray.SetHitPrim( leaf->primIdx[lane] );
+			t4 = c, tcur = t;
+		}
+		// skip entries behind the current hit
+		do { if (!stackPtr) goto the_end; nodeIdx = nodeStack[--stackPtr]; } while (distStack[stackPtr] > tcur);
+	}
+the_end:
+#ifdef _DEBUG
+	return steps;
+#else
+	return 0;
+#endif
+}
+
+#undef AVX_PUSH
+
+template <> template <bool posX, bool posY, bool posZ> bool impl::BVH4_CPU<double, uint64_t>::IsOccludedOctant( const Ray& ray ) const
+{
+	ALIGNED( 64 ) uint32_t nodeStack[TINYBVH_STACK_SIZE * 2 /* wide trees push more nodes per step */];
+	int32_t stackPtr = 0;
+	uint32_t nodeIdx = 0;
+	const __m256d t4 = _mm256_set1_pd( ray.hit.t );
+	const __m256d rx4 = _mm256_set1_pd( ray.O.x * ray.rD.x ), rdx4 = _mm256_set1_pd( ray.rD.x );
+	const __m256d ry4 = _mm256_set1_pd( ray.O.y * ray.rD.y ), rdy4 = _mm256_set1_pd( ray.rD.y );
+	const __m256d rz4 = _mm256_set1_pd( ray.O.z * ray.rD.z ), rdz4 = _mm256_set1_pd( ray.rD.z );
+	const __m256d ox4 = _mm256_set1_pd( ray.O.x ), oy4 = _mm256_set1_pd( ray.O.y ), oz4 = _mm256_set1_pd( ray.O.z );
+	const __m256d dx4 = _mm256_set1_pd( ray.D.x ), dy4 = _mm256_set1_pd( ray.D.y ), dz4 = _mm256_set1_pd( ray.D.z );
+	const __m256d one4 = _mm256_set1_pd( 1 ), zero4 = _mm256_setzero_pd();
+	while (1)
+	{
+		while (!(nodeIdx & LEAF_BIT))
+		{
+			const BVHNode* n = (BVHNode*)(bvh4Data + nodeIdx);
+			const uint32_t* child = n->child;
+			const __m256d tx1 = _mm256_fmsub_pd( _mm256_load_pd( posX ? n->xmin : n->xmax ), rdx4, rx4 );
+			const __m256d ty1 = _mm256_fmsub_pd( _mm256_load_pd( posY ? n->ymin : n->ymax ), rdy4, ry4 );
+			const __m256d tz1 = _mm256_fmsub_pd( _mm256_load_pd( posZ ? n->zmin : n->zmax ), rdz4, rz4 );
+			const __m256d tx2 = _mm256_fmsub_pd( _mm256_load_pd( posX ? n->xmax : n->xmin ), rdx4, rx4 );
+			const __m256d ty2 = _mm256_fmsub_pd( _mm256_load_pd( posY ? n->ymax : n->ymin ), rdy4, ry4 );
+			const __m256d tz2 = _mm256_fmsub_pd( _mm256_load_pd( posZ ? n->zmax : n->zmin ), rdz4, rz4 );
+			const __m256d tmin = _mm256_max_pd( _mm256_max_pd( zero4, tx1 ), _mm256_max_pd( ty1, tz1 ) );
+			const __m256d tmax = _mm256_min_pd( _mm256_min_pd( tx2, t4 ), _mm256_min_pd( ty2, tz2 ) );
+			// slab mask in lane order, the children are visited in any order
+			const uint32_t m = _mm256_movemask_pd( _mm256_cmp_pd( tmin, tmax, _CMP_LE_OQ ) );
+			const uint32_t c0 = child[0], c1 = child[1], c2 = child[2], c3 = child[3];
+			if (AVX_HIT( 0 ))
+			{
+				if (AVX_HIT( 3 )) nodeStack[stackPtr++] = c3;
+				if (AVX_HIT( 2 )) nodeStack[stackPtr++] = c2;
+				if (AVX_HIT( 1 )) nodeStack[stackPtr++] = c1;
+				nodeIdx = c0;
+			}
+			else if (AVX_HIT( 1 ))
+			{
+				if (AVX_HIT( 3 )) nodeStack[stackPtr++] = c3;
+				if (AVX_HIT( 2 )) nodeStack[stackPtr++] = c2;
+				nodeIdx = c1;
+			}
+			else if (AVX_HIT( 2 ))
+			{
+				if (AVX_HIT( 3 )) nodeStack[stackPtr++] = c3;
+				nodeIdx = c2;
+			}
+			else if (AVX_HIT( 3 )) nodeIdx = c3; else
+			{
+				if (!stackPtr) return false;
+				nodeIdx = nodeStack[--stackPtr];
+			}
+		}
+		// Moeller-Trumbore ray/triangle intersection algorithm for four triangles
+		const BVHTri4Leaf* leaf = (BVHTri4Leaf*)(bvh4Data + (nodeIdx & 0x1fffffff));
+		const __m256d hx4 = _mm256_fmsub_pd( dy4, _mm256_load_pd( leaf->e2z ), _mm256_mul_pd( dz4, _mm256_load_pd( leaf->e2y ) ) );
+		const __m256d hy4 = _mm256_fmsub_pd( dz4, _mm256_load_pd( leaf->e2x ), _mm256_mul_pd( dx4, _mm256_load_pd( leaf->e2z ) ) );
+		const __m256d hz4 = _mm256_fmsub_pd( dx4, _mm256_load_pd( leaf->e2y ), _mm256_mul_pd( dy4, _mm256_load_pd( leaf->e2x ) ) );
+		const __m256d sx4 = _mm256_sub_pd( ox4, _mm256_load_pd( leaf->v0x ) ), sy4 = _mm256_sub_pd( oy4, _mm256_load_pd( leaf->v0y ) ), sz4 = _mm256_sub_pd( oz4, _mm256_load_pd( leaf->v0z ) );
+		const __m256d det4 = _mm256_fmadd_pd( _mm256_load_pd( leaf->e1z ), hz4, _mm256_fmadd_pd( _mm256_load_pd( leaf->e1x ), hx4, _mm256_mul_pd( _mm256_load_pd( leaf->e1y ), hy4 ) ) );
+		const __m256d qz4 = _mm256_fmsub_pd( sx4, _mm256_load_pd( leaf->e1y ), _mm256_mul_pd( sy4, _mm256_load_pd( leaf->e1x ) ) );
+		const __m256d qx4 = _mm256_fmsub_pd( sy4, _mm256_load_pd( leaf->e1z ), _mm256_mul_pd( sz4, _mm256_load_pd( leaf->e1y ) ) );
+		const __m256d qy4 = _mm256_fmsub_pd( sz4, _mm256_load_pd( leaf->e1x ), _mm256_mul_pd( sx4, _mm256_load_pd( leaf->e1z ) ) );
+		const __m256d inv_det4 = _mm256_div_pd( one4, det4 );
+		const __m256d u4 = _mm256_mul_pd( _mm256_fmadd_pd( sz4, hz4, _mm256_fmadd_pd( sx4, hx4, _mm256_mul_pd( sy4, hy4 ) ) ), inv_det4 );
+		const __m256d v4 = _mm256_mul_pd( _mm256_fmadd_pd( dz4, qz4, _mm256_fmadd_pd( dx4, qx4, _mm256_mul_pd( dy4, qy4 ) ) ), inv_det4 );
+		const __m256d ta4 = _mm256_mul_pd( _mm256_fmadd_pd( _mm256_load_pd( leaf->e2z ), qz4, _mm256_fmadd_pd( _mm256_load_pd( leaf->e2x ), qx4, _mm256_mul_pd( _mm256_load_pd( leaf->e2y ), qy4 ) ) ), inv_det4 );
+		const __m256d mask1 = _mm256_and_pd( _mm256_cmp_pd( u4, zero4, _CMP_GE_OQ ), _mm256_cmp_pd( v4, zero4, _CMP_GE_OQ ) );
+		const __m256d mask2 = _mm256_cmp_pd( _mm256_add_pd( u4, v4 ), one4, _CMP_LE_OQ );
+		const __m256d mask3 = _mm256_and_pd( _mm256_cmp_pd( ta4, t4, _CMP_LT_OQ ), _mm256_cmp_pd( ta4, zero4, _CMP_GT_OQ ) );
+		const __m256d combined = _mm256_and_pd( _mm256_and_pd( mask1, mask2 ), mask3 );
+		const uint32_t imask = _mm256_movemask_pd( combined );
+		if (imask)
+		{
+			if (!opmap) return true;
+			// evaluate opacity map, AVX2 version.
+			const __m256d fN4 = _mm256_set1_pd( (double)opmapN );
+			const __m128i row4 = _mm256_cvttpd_epi32( _mm256_mul_pd( _mm256_add_pd( u4, v4 ), fN4 ) );
+			const __m128i dia4 = _mm256_cvttpd_epi32( _mm256_mul_pd( _mm256_sub_pd( one4, u4 ), fN4 ) );
+			const __m128i v0 = _mm_mullo_epi32( row4, row4 );
+			const __m128i v1 = _mm256_cvttpd_epi32( _mm256_mul_pd( v4, fN4 ) );
+			const __m128i v2 = _mm_sub_epi32( dia4, _mm_sub_epi32( _mm_set1_epi32( opmapN - 1 ), row4 ) );
+			uint32_t idx[4];
+			tinybvh_store4i( idx, _mm_add_epi32( _mm_add_epi32( v0, v1 ), v2 ) );
+			// gather the opacity bits with scalar loads
+			for (int i = 0; i < 4; i++) if (imask & (1 << i))
+			{
+				uint32_t* om = opmap + leaf->primIdx[i] * ((opmapN * opmapN + 31) >> 5);
+				if (om[idx[i] >> 5] & (1 << (idx[i] & 31))) return true;
+			}
+		}
+		// we continue.
+		if (!stackPtr) return false;
+		nodeIdx = nodeStack[--stackPtr];
+	}
+}
+
+#undef AVX_HIT
+
+} // namespace tinybvh
+
+#endif // TINYBVH_IMPLEMENTATION && DOUBLE_PRECISION_SUPPORT && BVH_USEAVX2

--- a/tiny_bvh_x86_float.h
+++ b/tiny_bvh_x86_float.h
@@ -43,7 +43,6 @@ template <> void impl::BVH<float, uint32_t>::PrepareSIMDBuildFragSlice( const ui
 template <> void impl::BVH<float, uint32_t>::BuildSIMDBinTask( const uint32_t first, const uint32_t last, void* binbox, uint32_t* count, const float* nmin4, const float* rpd4 );
 template <> void impl::BVH<float, uint32_t>::BuildSIMDSubtree( uint32_t nodeIdx, uint32_t depth );
 template <> void impl::BVH<float, uint32_t>::BuildSIMDFinalize();
-template <> void impl::BVH<float, uint32_t>::Intersect256RaysSSE( Ray* packet ) const;
 #endif
 #ifdef BVH_USEAVX2
 template <> template <bool posX, bool posY, bool posZ> int32_t impl::BVH8_CPU<float, uint32_t>::IntersectOctant( Ray& ray ) const;


### PR DESCRIPTION
This commit adds NEON/AVX2 translations of the single precision ``BVH4_CPU`` kernels. The NEON version splits every 4xFP32 operation into a pair of 2xFP64 operations. The AVX2 version runs the SSE kernel on 256-bit registers.

One complication is that AVX2 lacks the shuffle operation needed to reorder the slab test's result into the order of visit. The AVX2 kernel therefore handles the reordering using a scalar indirection. The NEON version can still shuffle the hit bits and only does this for ``tmin``.

The SIMD reference test compares SIMD and scalar versions, and the axis-aligned ray test was updated as well.

The speed test now templates its traversal benchmarks over the BVH and ray type, which removes the layout enum and its switch statements. Single and double precision paths share one implementation that also covers shadow and diffuse rays.

Single versus double precision on an M4 Max (Crytek Sponza, MRays/s):

```
              primary   shadow   diffuse
BVH4_CPU       10.72     21.56     3.79
BVH4_Double     8.26     16.16     3.25
BVH_Double      5.53      8.31     1.96
```

The same comparison on a Ryzen 9 7950X:

```
              primary   shadow   diffuse
BVH4_CPU       12.06     38.76     4.47
BVH4_Double    11.03     36.39     4.03
BVH_Double      3.92     17.62     1.54
```

Minor: I had to remove stale declarations of ``Intersect256RaysSSE`` to get things to compile.